### PR TITLE
Use Async Storage to store study file

### DIFF
--- a/config/debug.ts
+++ b/config/debug.ts
@@ -9,5 +9,6 @@ export function _DEBUG_CONFIGS() {
     ignoreLogin: true,
     ignoreNotificationTime: true,
     showCurrentStatesInSurveyScreen: false,
+    alwaysRedownloadStudyFile: true,
   };
 }

--- a/config/survey.json
+++ b/config/survey.json
@@ -11,6 +11,10 @@
       "hoursEveryday": [9, 13, 17, 21],
       "randomMinuteAddition": { "min": 0, "max": 119 }
     },
+    "streamsStartingQuestionIds": {
+      "myStream": "Feel_Current",
+      "errorStream": "firstQuestion"
+    },
     "streamsOrder": {
       "0": ["myStream", "myStream", "myStream", "myStream"],
       "1": ["myStream", "myStream", "myStream", "myStream"],
@@ -34,12 +38,6 @@
       }
     },
     "serverURL": "https://wellping.hesyifei.com/"
-  },
-  "meta": {
-    "startingQuestionIds": {
-      "myStream": "Feel_Current",
-      "errorStream": "firstQuestion"
-    }
   },
   "streams": {
     "myStream": {

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -38,7 +38,6 @@ import {
   clearPingStateAsync,
 } from "./helpers/asyncStorage/pingState";
 import { getUserAsync } from "./helpers/asyncStorage/user";
-import { getAllStreamNames, getStudyInfoAsync } from "./helpers/configFiles";
 import {
   shareDatabaseFileAsync,
   deleteDatabaseFileAsync,
@@ -61,13 +60,8 @@ import {
   insertPingAsync,
   getNumbersOfPingsForAllStreamNames,
 } from "./helpers/pings";
-import {
-  Streams,
-  QuestionsList,
-  StudyFile,
-  StreamName,
-  StudyInfo,
-} from "./helpers/types";
+import { getAllStreamNames, getStudyInfoAsync } from "./helpers/studyFile";
+import { Streams, StreamName, StudyInfo } from "./helpers/types";
 
 const styles = StyleSheet.create({
   onlyTextStyle: {

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -38,7 +38,7 @@ import {
   clearPingStateAsync,
 } from "./helpers/asyncStorage/pingState";
 import { getUserAsync } from "./helpers/asyncStorage/user";
-import { getAllStreamNames } from "./helpers/configFiles";
+import { getAllStreamNames, getStudyInfoAsync } from "./helpers/configFiles";
 import {
   shareDatabaseFileAsync,
   deleteDatabaseFileAsync,
@@ -380,6 +380,13 @@ export default class HomeScreen extends React.Component<
               await answer.save();*/
 
               await shareDatabaseFileAsync(studyInfo.id);
+            }}
+          />
+          <Button
+            color="orange"
+            title="getStudyInfoAsync()"
+            onPress={async () => {
+              alert(JSON.stringify(await getStudyInfoAsync()));
             }}
           />
           <Button

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -79,7 +79,8 @@ const styles = StyleSheet.create({
 });
 
 interface HomeScreenProps {
-  survey: StudyFile;
+  studyInfo: StudyInfo;
+  streams: Streams;
   logout: () => Promise<void>;
 }
 
@@ -148,7 +149,7 @@ export default class HomeScreen extends React.Component<
       await Notifications.setBadgeNumberAsync(0);
     }
 
-    const studyInfo = this.props.survey.studyInfo;
+    const studyInfo = this.props.studyInfo;
     await setNotificationsAsync(studyInfo);
 
     const doEveryHalfMinutes = async () => {
@@ -200,7 +201,7 @@ export default class HomeScreen extends React.Component<
   }
 
   async startSurveyAsync() {
-    const studyInfo = this.props.survey.studyInfo;
+    const studyInfo = this.props.studyInfo;
 
     const todayWeekday = getDay(new Date());
     const todayPings = await getTodayPingsAsync();
@@ -250,8 +251,7 @@ export default class HomeScreen extends React.Component<
   }
 
   render() {
-    const { survey } = this.props;
-    const studyInfo = survey.studyInfo;
+    const { studyInfo, streams } = this.props;
 
     const {
       allowsNotifications,
@@ -384,7 +384,7 @@ export default class HomeScreen extends React.Component<
               answer.lastUpdateDate = new Date();
               await answer.save();*/
 
-              await shareDatabaseFileAsync(survey.studyInfo.id);
+              await shareDatabaseFileAsync(studyInfo.id);
             }}
           />
           <Button
@@ -600,7 +600,7 @@ export default class HomeScreen extends React.Component<
 
     if (currentPing == null) {
       const streamButtons = [];
-      for (const streamName of getAllStreamNames(survey)) {
+      for (const streamName of getAllStreamNames(studyInfo)) {
         streamButtons.push(
           <Button
             color="orange"
@@ -651,9 +651,9 @@ export default class HomeScreen extends React.Component<
       <View style={{ height: "100%" }}>
         {ExtraView}
         <SurveyScreen
-          survey={survey.streams[currentPing.streamName]}
+          survey={streams[currentPing.streamName]}
           surveyStartingQuestionId={
-            survey.studyInfo.streamsStartingQuestionIds[currentPing.streamName]
+            studyInfo.streamsStartingQuestionIds[currentPing.streamName]
           }
           ping={currentPing}
           previousState={this.state.storedPingStateAsync}

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -43,7 +43,11 @@ import {
   shareDatabaseFileAsync,
   deleteDatabaseFileAsync,
 } from "./helpers/database";
-import { getNonCriticalProblemTextForUser } from "./helpers/debug";
+import {
+  getNonCriticalProblemTextForUser,
+  VERSION_NUMBER,
+  getUsefulDebugInfo,
+} from "./helpers/debug";
 import {
   setNotificationsAsync,
   setupNotificationsPermissionAsync,
@@ -64,8 +68,6 @@ import {
   StreamName,
   StudyInfo,
 } from "./helpers/types";
-
-const VERSION_NUMBER = "1.1.0";
 
 const styles = StyleSheet.create({
   onlyTextStyle: {
@@ -295,7 +297,7 @@ export default class HomeScreen extends React.Component<
                       `Please enter your question here (please attach a screenshot if applicable):\n\n\n\n\n\n` +
                         `====\n` +
                         `User ID: ${user!.patientId}\n` +
-                        `Version: ${VERSION_NUMBER}`,
+                        getUsefulDebugInfo(),
                     );
                     const mailtoLink = `mailto:${studyInfo.contactEmail}?subject=${emailSubject}&body=${emailBody}`;
                     Linking.openURL(mailtoLink);

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -570,7 +570,7 @@ export default class HomeScreen extends React.Component<
                     text: "Confirm",
                     style: "destructive",
                     onPress: async () => {
-                      await deleteDatabaseFileAsync(survey.studyInfo.id);
+                      await deleteDatabaseFileAsync(studyInfo.id);
                       alert("Done! Please restart the app.");
                     },
                   },

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -653,7 +653,7 @@ export default class HomeScreen extends React.Component<
         <SurveyScreen
           survey={survey.streams[currentPing.streamName]}
           surveyStartingQuestionId={
-            survey.meta.startingQuestionIds[currentPing.streamName]
+            survey.studyInfo.streamsStartingQuestionIds[currentPing.streamName]
           }
           ping={currentPing}
           previousState={this.state.storedPingStateAsync}

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -149,13 +149,10 @@ export default class HomeScreen extends React.Component<
       await Notifications.setBadgeNumberAsync(0);
     }
 
-    const studyInfo = this.props.studyInfo;
-    await setNotificationsAsync(studyInfo);
+    await setNotificationsAsync();
 
     const doEveryHalfMinutes = async () => {
-      const currentNotificationTime = await getCurrentNotificationTimeAsync(
-        studyInfo,
-      );
+      const currentNotificationTime = await getCurrentNotificationTimeAsync();
       this.setState({ time: new Date(), currentNotificationTime });
 
       if (currentNotificationTime == null) {
@@ -176,9 +173,7 @@ export default class HomeScreen extends React.Component<
 
     const latestPing = await getLatestPingAsync();
     //console.warn(latestStartedPing);
-    const currentNotificationTime = await getCurrentNotificationTimeAsync(
-      studyInfo,
-    );
+    const currentNotificationTime = await getCurrentNotificationTimeAsync();
     if (
       latestPing &&
       currentNotificationTime &&
@@ -233,7 +228,7 @@ export default class HomeScreen extends React.Component<
     await this._startSurveyTypeAsync(newPingName);
 
     // So that the notification text ("n pings left") can be updated.
-    await setNotificationsAsync(studyInfo);
+    await setNotificationsAsync();
   }
 
   async _startSurveyTypeAsync(streamName: StreamName) {
@@ -411,9 +406,7 @@ export default class HomeScreen extends React.Component<
             color="orange"
             title="getCurrentNotificationTimeAsync()"
             onPress={async () => {
-              const currentNotificationTime = await getCurrentNotificationTimeAsync(
-                studyInfo,
-              );
+              const currentNotificationTime = await getCurrentNotificationTimeAsync();
               alert(JSON.stringify(currentNotificationTime));
             }}
           />

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -9,7 +9,7 @@ import {
   User,
   clearUserAsync,
 } from "./helpers/asyncStorage/user";
-import { getSurveyFileAsync } from "./helpers/configFiles";
+import { getStudyFileAsync } from "./helpers/configFiles";
 import { connectDatabaseAsync } from "./helpers/database";
 import { getCriticalProblemTextForUser } from "./helpers/debug";
 import { StudyFile } from "./helpers/types";
@@ -43,7 +43,7 @@ export default class RootScreen extends React.Component<
   async componentDidMount() {
     const user = await getUserAsync();
     if (user) {
-      const survey = await getSurveyFileAsync();
+      const survey = await getStudyFileAsync();
 
       await connectDatabaseAsync(survey.studyInfo.id);
 
@@ -150,14 +150,14 @@ export default class RootScreen extends React.Component<
                       text: "Review",
                       onPress: async () => {
                         await WebBrowser.openBrowserAsync(
-                          (await getSurveyFileAsync()).studyInfo.consentFormUrl,
+                          (await getStudyFileAsync()).studyInfo.consentFormUrl,
                         );
                         this.setState({
                           errorText: "Downloading survey...",
                         });
 
                         // TODO: await downloadSurvey;
-                        const survey = await getSurveyFileAsync();
+                        const survey = await getStudyFileAsync();
 
                         this.setState({
                           userInfo: user,

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -277,7 +277,8 @@ export default class RootScreen extends React.Component<
 
     return (
       <HomeScreen
-        survey={this.state.survey}
+        studyInfo={this.state.survey.studyInfo}
+        streams={this.state.survey.streams}
         logout={async () => {
           await clearUserAsync();
           this.setState({ userInfo: null });

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -9,13 +9,13 @@ import {
   User,
   clearUserAsync,
 } from "./helpers/asyncStorage/user";
+import { connectDatabaseAsync } from "./helpers/database";
+import { getCriticalProblemTextForUser, shareDebugText } from "./helpers/debug";
 import {
   getStudyFileAsync,
   downloadStudyFileAsync,
   shouldDownloadStudyFileAsync,
-} from "./helpers/configFiles";
-import { connectDatabaseAsync } from "./helpers/database";
-import { getCriticalProblemTextForUser, shareDebugText } from "./helpers/debug";
+} from "./helpers/studyFile";
 import { StudyFile } from "./helpers/types";
 
 interface RootScreenProps {}

--- a/src/__tests__/data/pings.ts
+++ b/src/__tests__/data/pings.ts
@@ -128,6 +128,12 @@ export const PINGS_STUDY_INFO: StudyInfo = {
     hoursEveryday: [8, 10, 12, 16, 18, 22],
     randomMinuteAddition: { min: 0, max: 89 },
   },
+  streamsStartingQuestionIds: {
+    cat: "hello_cat",
+    dog: "hello_dog",
+    wolf: "hello_wolf",
+    lynx: "hello_lynx",
+  },
   streamsOrder: {
     0: ["cat", "dog", "wolf", "lynx", "cat", "dog"],
     1: ["cat", "dog", "wolf", "lynx", "cat", "dog"],

--- a/src/__tests__/helper.ts
+++ b/src/__tests__/helper.ts
@@ -4,6 +4,16 @@ import { FunctionSpyInstance } from "./jestHelper";
 
 export const simplePipeInExtraMetaData = (id: string) => id;
 
+/**
+ * Notice that it is possible to `mockStudyInfo` in an outer `beforeEach`,
+ * and then `mockStudyInfo` again in an inner `beforeEach`.
+ * The `mockStudyInfo` in the inner `beforeEach` will override the outer one.
+ *
+ * Reference:
+ * - https://stackoverflow.com/a/54166834/2603230
+ * - https://jestjs.io/docs/en/setup-teardown#scoping
+ * - https://stackoverflow.com/a/52994828/2603230
+ */
 export function mockCurrentStudyInfo(
   mockStudyInfo: StudyInfo,
 ): FunctionSpyInstance<typeof studyFileAsyncStorage.getCurrentStudyInfoAsync> {

--- a/src/__tests__/helper.ts
+++ b/src/__tests__/helper.ts
@@ -1,1 +1,15 @@
+import * as studyFileAsyncStorage from "../helpers/asyncStorage/studyFile";
+import { StudyInfo } from "../helpers/types";
+import { FunctionSpyInstance } from "./jestHelper";
+
 export const simplePipeInExtraMetaData = (id: string) => id;
+
+export function mockCurrentStudyInfo(
+  mockStudyInfo: StudyInfo,
+): FunctionSpyInstance<typeof studyFileAsyncStorage.getCurrentStudyInfoAsync> {
+  return jest
+    .spyOn(studyFileAsyncStorage, "getCurrentStudyInfoAsync")
+    .mockImplementation(async () => {
+      return mockStudyInfo;
+    });
+}

--- a/src/__tests__/helpers/configFiles.test.ts
+++ b/src/__tests__/helpers/configFiles.test.ts
@@ -1,6 +1,6 @@
 import * as DateMock from "jest-date-mock";
 
-import { isTimeThisWeek } from "../../helpers/configFiles";
+import { isTimeThisWeek } from "../../helpers/studyFile";
 
 describe("isTimeThisWeek", () => {
   beforeEach(() => {

--- a/src/__tests__/helpers/notifications.parttest.ts
+++ b/src/__tests__/helpers/notifications.parttest.ts
@@ -36,6 +36,8 @@ export const notificationsTest = () => {
     mathRandomSpy = jest
       .spyOn(global.Math, "random")
       .mockReturnValue(0.123456789);
+
+    mockCurrentStudyInfo(PINGS_STUDY_INFO);
   });
   afterEach(() => {
     DateMock.clear();
@@ -58,7 +60,6 @@ export const notificationsTest = () => {
     test("after the study already ends", async () => {
       DateMock.advanceTo(+new Date("2010-08-08T20:08:08Z"));
 
-      mockCurrentStudyInfo(PINGS_STUDY_INFO);
       await setNotificationsAsync();
 
       expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -69,7 +70,6 @@ export const notificationsTest = () => {
     test("before the study starts", async () => {
       DateMock.advanceTo(+new Date("2010-04-20T20:08:08Z"));
 
-      mockCurrentStudyInfo(PINGS_STUDY_INFO);
       await setNotificationsAsync();
 
       expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -83,7 +83,6 @@ export const notificationsTest = () => {
     test("near study ends", async () => {
       DateMock.advanceTo(+new Date("2010-05-28T20:08:08Z"));
 
-      mockCurrentStudyInfo(PINGS_STUDY_INFO);
       await setNotificationsAsync();
 
       expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -120,7 +119,6 @@ export const notificationsTest = () => {
       test("(at the start of the day)", async () => {
         DateMock.advanceTo(+new Date("2010-05-11T08:00:00Z"));
 
-        mockCurrentStudyInfo(PINGS_STUDY_INFO);
         await setNotificationsAsync();
 
         expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -141,7 +139,6 @@ export const notificationsTest = () => {
       test("(in the middle of the day)", async () => {
         DateMock.advanceTo(+new Date("2010-05-11T13:00:00Z"));
 
-        mockCurrentStudyInfo(PINGS_STUDY_INFO);
         await setNotificationsAsync();
 
         expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -165,7 +162,6 @@ export const notificationsTest = () => {
         test("(stay in current week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-03T10:01:00Z"));
 
-          mockCurrentStudyInfo(PINGS_STUDY_INFO);
           await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -181,7 +177,6 @@ export const notificationsTest = () => {
         test("(jump to next week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-01T11:00:00Z"));
 
-          mockCurrentStudyInfo(PINGS_STUDY_INFO);
           await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -198,7 +193,6 @@ export const notificationsTest = () => {
       test("(1 ping from reaching bonus)", async () => {
         DateMock.advanceTo(+new Date("2010-05-11T13:01:00Z"));
 
-        mockCurrentStudyInfo(PINGS_STUDY_INFO);
         await setNotificationsAsync();
 
         expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -213,7 +207,6 @@ export const notificationsTest = () => {
         test("(stay in current week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-11T17:01:00Z"));
 
-          mockCurrentStudyInfo(PINGS_STUDY_INFO);
           await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -229,7 +222,6 @@ export const notificationsTest = () => {
         test("(jump to next week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-15T14:01:00Z"));
 
-          mockCurrentStudyInfo(PINGS_STUDY_INFO);
           await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -252,10 +244,13 @@ export const notificationsTest = () => {
           },
         };
 
+        beforeEach(() => {
+          mockCurrentStudyInfo(PINGS_STUDY_INFO_WITH_NO_BONUS);
+        });
+
         test("(stay in current week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-11T17:01:00Z"));
 
-          mockCurrentStudyInfo(PINGS_STUDY_INFO_WITH_NO_BONUS);
           await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -284,7 +279,6 @@ export const notificationsTest = () => {
         test("(jump to next week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-15T14:01:00Z"));
 
-          mockCurrentStudyInfo(PINGS_STUDY_INFO_WITH_NO_BONUS);
           await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
@@ -338,8 +332,6 @@ export const notificationsTest = () => {
       });
 
       test("before and after a ping", async () => {
-        mockCurrentStudyInfo(PINGS_STUDY_INFO);
-
         DateMock.advanceTo(+new Date("2010-05-12T12:57:00Z"));
         expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
           `null`,
@@ -367,8 +359,6 @@ export const notificationsTest = () => {
       });
 
       test("expired ping", async () => {
-        mockCurrentStudyInfo(PINGS_STUDY_INFO);
-
         DateMock.advanceTo(+new Date("2010-05-12T14:01:00Z"));
         expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
           `null`,
@@ -377,8 +367,6 @@ export const notificationsTest = () => {
     });
 
     test("without stored notification times", async () => {
-      mockCurrentStudyInfo(PINGS_STUDY_INFO);
-
       DateMock.advanceTo(+new Date("2010-05-12T13:00:08Z"));
       expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
         `null`,

--- a/src/__tests__/helpers/notifications.parttest.ts
+++ b/src/__tests__/helpers/notifications.parttest.ts
@@ -14,6 +14,7 @@ import {
   connectTestDatabaseAsync,
 } from "../data/database_helper";
 import { PINGS_STUDY_INFO } from "../data/pings";
+import { mockCurrentStudyInfo } from "../helper";
 import { FunctionSpyInstance } from "../jestHelper";
 import { PINGS_DB_NAME } from "./pings.parttest";
 
@@ -57,7 +58,8 @@ export const notificationsTest = () => {
     test("after the study already ends", async () => {
       DateMock.advanceTo(+new Date("2010-08-08T20:08:08Z"));
 
-      await setNotificationsAsync(PINGS_STUDY_INFO);
+      mockCurrentStudyInfo(PINGS_STUDY_INFO);
+      await setNotificationsAsync();
 
       expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -67,7 +69,8 @@ export const notificationsTest = () => {
     test("before the study starts", async () => {
       DateMock.advanceTo(+new Date("2010-04-20T20:08:08Z"));
 
-      await setNotificationsAsync(PINGS_STUDY_INFO);
+      mockCurrentStudyInfo(PINGS_STUDY_INFO);
+      await setNotificationsAsync();
 
       expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -80,7 +83,8 @@ export const notificationsTest = () => {
     test("near study ends", async () => {
       DateMock.advanceTo(+new Date("2010-05-28T20:08:08Z"));
 
-      await setNotificationsAsync(PINGS_STUDY_INFO);
+      mockCurrentStudyInfo(PINGS_STUDY_INFO);
+      await setNotificationsAsync();
 
       expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -116,7 +120,8 @@ export const notificationsTest = () => {
       test("(at the start of the day)", async () => {
         DateMock.advanceTo(+new Date("2010-05-11T08:00:00Z"));
 
-        await setNotificationsAsync(PINGS_STUDY_INFO);
+        mockCurrentStudyInfo(PINGS_STUDY_INFO);
+        await setNotificationsAsync();
 
         expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -136,7 +141,8 @@ export const notificationsTest = () => {
       test("(in the middle of the day)", async () => {
         DateMock.advanceTo(+new Date("2010-05-11T13:00:00Z"));
 
-        await setNotificationsAsync(PINGS_STUDY_INFO);
+        mockCurrentStudyInfo(PINGS_STUDY_INFO);
+        await setNotificationsAsync();
 
         expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -159,7 +165,8 @@ export const notificationsTest = () => {
         test("(stay in current week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-03T10:01:00Z"));
 
-          await setNotificationsAsync(PINGS_STUDY_INFO);
+          mockCurrentStudyInfo(PINGS_STUDY_INFO);
+          await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -174,7 +181,8 @@ export const notificationsTest = () => {
         test("(jump to next week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-01T11:00:00Z"));
 
-          await setNotificationsAsync(PINGS_STUDY_INFO);
+          mockCurrentStudyInfo(PINGS_STUDY_INFO);
+          await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -190,7 +198,8 @@ export const notificationsTest = () => {
       test("(1 ping from reaching bonus)", async () => {
         DateMock.advanceTo(+new Date("2010-05-11T13:01:00Z"));
 
-        await setNotificationsAsync(PINGS_STUDY_INFO);
+        mockCurrentStudyInfo(PINGS_STUDY_INFO);
+        await setNotificationsAsync();
 
         expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -204,7 +213,8 @@ export const notificationsTest = () => {
         test("(stay in current week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-11T17:01:00Z"));
 
-          await setNotificationsAsync(PINGS_STUDY_INFO);
+          mockCurrentStudyInfo(PINGS_STUDY_INFO);
+          await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -219,7 +229,8 @@ export const notificationsTest = () => {
         test("(jump to next week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-15T14:01:00Z"));
 
-          await setNotificationsAsync(PINGS_STUDY_INFO);
+          mockCurrentStudyInfo(PINGS_STUDY_INFO);
+          await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -244,7 +255,8 @@ export const notificationsTest = () => {
         test("(stay in current week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-11T17:01:00Z"));
 
-          await setNotificationsAsync(PINGS_STUDY_INFO_WITH_NO_BONUS);
+          mockCurrentStudyInfo(PINGS_STUDY_INFO_WITH_NO_BONUS);
+          await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -272,7 +284,8 @@ export const notificationsTest = () => {
         test("(jump to next week)", async () => {
           DateMock.advanceTo(+new Date("2010-05-15T14:01:00Z"));
 
-          await setNotificationsAsync(PINGS_STUDY_INFO_WITH_NO_BONUS);
+          mockCurrentStudyInfo(PINGS_STUDY_INFO_WITH_NO_BONUS);
+          await setNotificationsAsync();
 
           expect(spyCancelAllScheduledNotificationsAsync).toBeCalledTimes(1);
 
@@ -325,45 +338,51 @@ export const notificationsTest = () => {
       });
 
       test("before and after a ping", async () => {
+        mockCurrentStudyInfo(PINGS_STUDY_INFO);
+
         DateMock.advanceTo(+new Date("2010-05-12T12:57:00Z"));
-        expect(
-          await getCurrentNotificationTimeAsync(PINGS_STUDY_INFO),
-        ).toMatchInlineSnapshot(`null`);
+        expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
+          `null`,
+        );
 
         DateMock.advanceTo(+new Date("2010-05-12T12:57:08Z"));
-        expect(
-          await getCurrentNotificationTimeAsync(PINGS_STUDY_INFO),
-        ).toMatchInlineSnapshot(`2010-05-12T12:57:07.000Z`);
+        expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
+          `2010-05-12T12:57:07.000Z`,
+        );
 
         DateMock.advanceTo(+new Date("2010-05-12T13:00:08Z"));
-        expect(
-          await getCurrentNotificationTimeAsync(PINGS_STUDY_INFO),
-        ).toMatchInlineSnapshot(`2010-05-12T12:57:07.000Z`);
+        expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
+          `2010-05-12T12:57:07.000Z`,
+        );
 
         DateMock.advanceTo(+new Date("2010-05-12T13:26:59Z"));
-        expect(
-          await getCurrentNotificationTimeAsync(PINGS_STUDY_INFO),
-        ).toMatchInlineSnapshot(`2010-05-12T12:57:07.000Z`);
+        expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
+          `2010-05-12T12:57:07.000Z`,
+        );
 
         DateMock.advanceTo(+new Date("2010-05-12T13:27:08Z"));
-        expect(
-          await getCurrentNotificationTimeAsync(PINGS_STUDY_INFO),
-        ).toMatchInlineSnapshot(`null`);
+        expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
+          `null`,
+        );
       });
 
       test("expired ping", async () => {
+        mockCurrentStudyInfo(PINGS_STUDY_INFO);
+
         DateMock.advanceTo(+new Date("2010-05-12T14:01:00Z"));
-        expect(
-          await getCurrentNotificationTimeAsync(PINGS_STUDY_INFO),
-        ).toMatchInlineSnapshot(`null`);
+        expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
+          `null`,
+        );
       });
     });
 
     test("without stored notification times", async () => {
+      mockCurrentStudyInfo(PINGS_STUDY_INFO);
+
       DateMock.advanceTo(+new Date("2010-05-12T13:00:08Z"));
-      expect(
-        await getCurrentNotificationTimeAsync(PINGS_STUDY_INFO),
-      ).toMatchInlineSnapshot(`null`);
+      expect(await getCurrentNotificationTimeAsync()).toMatchInlineSnapshot(
+        `null`,
+      );
     });
   });
 

--- a/src/__tests__/helpers/pings.parttest.ts
+++ b/src/__tests__/helpers/pings.parttest.ts
@@ -17,7 +17,8 @@ import {
   connectTestDatabaseAsync,
   getTestDatabaseFilename,
 } from "../data/database_helper";
-import { PINGS, PINGS_DICT } from "../data/pings";
+import { PINGS, PINGS_DICT, PINGS_STUDY_INFO } from "../data/pings";
+import { mockCurrentStudyInfo } from "../helper";
 
 export const PINGS_DB_NAME = "pings";
 
@@ -35,6 +36,10 @@ export const pingsTest = () => {
   });
   afterAll(async () => {
     await connection.close();
+  });
+
+  beforeEach(() => {
+    mockCurrentStudyInfo(PINGS_STUDY_INFO);
   });
 
   test("insert pings and set end date", async () => {
@@ -109,22 +114,6 @@ export const pingsTest = () => {
     DateMock.advanceTo(+new Date("2010-05-01T08:08:08Z"));
     expect(await getTodayPingsAsync()).toEqual([]);
 
-    DateMock.advanceTo(+new Date("2010-05-01T10:00:08Z"));
-    expect(await getThisWeekPingsAsync()).toEqual([PINGS_DICT["cat1"]]);
-
-    DateMock.advanceTo(+new Date("2010-05-01T18:58:08Z"));
-    expect(await getThisWeekPingsAsync()).toEqual([
-      PINGS_DICT["cat1"],
-      PINGS_DICT["dog1"],
-    ]);
-
-    DateMock.advanceTo(+new Date("2010-05-01T22:46:08Z"));
-    expect(await getThisWeekPingsAsync()).toEqual([
-      PINGS_DICT["cat1"],
-      PINGS_DICT["dog1"],
-      PINGS_DICT["wolf1"],
-    ]);
-
     DateMock.advanceTo(+new Date("2010-05-02T08:08:08Z"));
     expect(await getTodayPingsAsync()).toEqual([]);
 
@@ -156,8 +145,6 @@ export const pingsTest = () => {
   });
 
   test("get this week's ping", async () => {
-    // TODO: weekStartsOn IS NOT CONSIDERED HERE.
-
     DateMock.advanceTo(+new Date("2010-04-30T08:08:08Z"));
     expect(await getThisWeekPingsAsync()).toEqual([]);
 

--- a/src/helpers/apiManager.ts
+++ b/src/helpers/apiManager.ts
@@ -7,8 +7,8 @@ import { AnswerEntity } from "../entities/AnswerEntity";
 import { PingEntity } from "../entities/PingEntity";
 import { getAnswersAsync } from "./answers";
 import { User, storeUserAsync, getUserAsync } from "./asyncStorage/user";
-import { getStudyInfoAsync } from "./configFiles";
 import { getPingsAsync } from "./pings";
+import { getStudyInfoAsync } from "./studyFile";
 
 export async function getServerUrlAsync(): Promise<string> {
   return (await getStudyInfoAsync()).serverURL;

--- a/src/helpers/apiManager.ts
+++ b/src/helpers/apiManager.ts
@@ -7,11 +7,11 @@ import { AnswerEntity } from "../entities/AnswerEntity";
 import { PingEntity } from "../entities/PingEntity";
 import { getAnswersAsync } from "./answers";
 import { User, storeUserAsync, getUserAsync } from "./asyncStorage/user";
-import { getStudyFileAsync } from "./configFiles";
+import { getStudyInfoAsync } from "./configFiles";
 import { getPingsAsync } from "./pings";
 
 export async function getServerUrlAsync(): Promise<string> {
-  return (await getStudyFileAsync()).studyInfo.serverURL;
+  return (await getStudyInfoAsync()).serverURL;
 }
 
 type UploadData = {

--- a/src/helpers/apiManager.ts
+++ b/src/helpers/apiManager.ts
@@ -7,11 +7,11 @@ import { AnswerEntity } from "../entities/AnswerEntity";
 import { PingEntity } from "../entities/PingEntity";
 import { getAnswersAsync } from "./answers";
 import { User, storeUserAsync, getUserAsync } from "./asyncStorage/user";
-import { getSurveyFileAsync } from "./configFiles";
+import { getStudyFileAsync } from "./configFiles";
 import { getPingsAsync } from "./pings";
 
 export async function getServerUrlAsync(): Promise<string> {
-  return (await getSurveyFileAsync()).studyInfo.serverURL;
+  return (await getStudyFileAsync()).studyInfo.serverURL;
 }
 
 type UploadData = {

--- a/src/helpers/asyncStorage/asyncStorage.ts
+++ b/src/helpers/asyncStorage/asyncStorage.ts
@@ -1,6 +1,6 @@
-import { getSurveyFileAsync } from "../configFiles";
+import { getStudyFileAsync } from "../configFiles";
 
 export async function getASKeyAsync(key: string = ""): Promise<string> {
-  const studyId = (await getSurveyFileAsync()).studyInfo.id;
+  const studyId = (await getStudyFileAsync()).studyInfo.id;
   return `@WELLPING:Study_${studyId}/${key}`; //TODO: ADD ENCODED URL HERE
 }

--- a/src/helpers/asyncStorage/asyncStorage.ts
+++ b/src/helpers/asyncStorage/asyncStorage.ts
@@ -1,4 +1,4 @@
-import { getStudyInfoAsync } from "../configFiles";
+import { getStudyInfoAsync } from "../studyFile";
 
 export async function getASKeyAsync(key: string = ""): Promise<string> {
   const studyInfo = await getStudyInfoAsync();

--- a/src/helpers/asyncStorage/asyncStorage.ts
+++ b/src/helpers/asyncStorage/asyncStorage.ts
@@ -1,6 +1,8 @@
 import { getStudyFileAsync } from "../configFiles";
 
+export const WELLPING_PREFIX = "@WELLPING:";
+
 export async function getASKeyAsync(key: string = ""): Promise<string> {
-  const studyId = (await getStudyFileAsync()).studyInfo.id;
-  return `@WELLPING:Study_${studyId}/${key}`; //TODO: ADD ENCODED URL HERE
+  const studyInfo = (await getStudyFileAsync()).studyInfo;
+  return `${WELLPING_PREFIX}Study_${studyInfo.id}/${key}`; //TODO: ADD ENCODED URL HERE
 }

--- a/src/helpers/asyncStorage/asyncStorage.ts
+++ b/src/helpers/asyncStorage/asyncStorage.ts
@@ -1,6 +1,6 @@
-import { getStudyFileAsync } from "../configFiles";
+import { getStudyInfoAsync } from "../configFiles";
 
 export async function getASKeyAsync(key: string = ""): Promise<string> {
-  const studyInfo = (await getStudyFileAsync()).studyInfo;
+  const studyInfo = await getStudyInfoAsync();
   return `@WELLPING:Study_${studyInfo.id}/${key}`; //TODO: ADD ENCODED URL HERE
 }

--- a/src/helpers/asyncStorage/asyncStorage.ts
+++ b/src/helpers/asyncStorage/asyncStorage.ts
@@ -1,8 +1,6 @@
 import { getStudyFileAsync } from "../configFiles";
 
-export const WELLPING_PREFIX = "@WELLPING:";
-
 export async function getASKeyAsync(key: string = ""): Promise<string> {
   const studyInfo = (await getStudyFileAsync()).studyInfo;
-  return `${WELLPING_PREFIX}Study_${studyInfo.id}/${key}`; //TODO: ADD ENCODED URL HERE
+  return `@WELLPING:Study_${studyInfo.id}/${key}`; //TODO: ADD ENCODED URL HERE
 }

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -1,14 +1,20 @@
 import { AsyncStorage } from "react-native";
 
 import { logError } from "../debug";
-import { parseJsonToStudyFile } from "../schemas/StudyFile";
-import { StudyFile } from "../types";
+import { parseJsonToStreams } from "../schemas/Stream";
+import { parseJsonToStudyInfo } from "../schemas/StudyFile";
+import { StudyFile, Streams, StudyInfo } from "../types";
 
-const STUDY_FILE_KEY = `currentStudyFile`;
+const STUDY_INFO_KEY = `currentStudyFile_StudyInfo`;
+const STREAMS_KEY = `currentStudyFile_Streams`;
 
 export async function storeCurrentStudyFileAsync(studyFile: StudyFile) {
   try {
-    await AsyncStorage.setItem(STUDY_FILE_KEY, JSON.stringify(studyFile));
+    await AsyncStorage.setItem(
+      STUDY_INFO_KEY,
+      JSON.stringify(studyFile.studyInfo),
+    );
+    await AsyncStorage.setItem(STREAMS_KEY, JSON.stringify(studyFile.streams));
   } catch (error) {
     // Error saving data
     logError(error);
@@ -17,24 +23,54 @@ export async function storeCurrentStudyFileAsync(studyFile: StudyFile) {
 
 export async function clearCurrentStudyFileAsync() {
   try {
-    await AsyncStorage.removeItem(STUDY_FILE_KEY);
+    await AsyncStorage.removeItem(STUDY_INFO_KEY);
+    await AsyncStorage.removeItem(STREAMS_KEY);
   } catch (error) {
     // Error saving data
     logError(error);
   }
 }
 
-export async function getCurrentStudyFileAsync(): Promise<StudyFile | null> {
+export async function getCurrentStudyInfoAsync(): Promise<StudyInfo | null> {
   try {
-    const value = await AsyncStorage.getItem(STUDY_FILE_KEY);
+    const value = await AsyncStorage.getItem(STUDY_INFO_KEY);
     if (value == null) {
       return null;
     }
-    const studyFile: StudyFile = parseJsonToStudyFile(JSON.parse(value));
-    return studyFile;
+    const studyInfo: StudyInfo = parseJsonToStudyInfo(JSON.parse(value));
+    return studyInfo;
   } catch (error) {
     // Error retrieving data
     logError(error);
     return null;
   }
+}
+
+export async function getCurrentStreamsAsync(): Promise<Streams | null> {
+  try {
+    const value = await AsyncStorage.getItem(STREAMS_KEY);
+    if (value == null) {
+      return null;
+    }
+    const streams: Streams = parseJsonToStreams(JSON.parse(value));
+    return streams;
+  } catch (error) {
+    // Error retrieving data
+    logError(error);
+    return null;
+  }
+}
+
+export async function studyFileExistsAsync() {
+  const currentStudyInfo = await getCurrentStudyInfoAsync();
+  if (currentStudyInfo === null) {
+    return false;
+  }
+
+  const currentStreams = await getCurrentStreamsAsync();
+  if (currentStreams === null) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -1,0 +1,32 @@
+import { AsyncStorage } from "react-native";
+
+import { logError } from "../debug";
+import { parseJsonToStudyFile } from "../schemas/StudyFile";
+import { StudyFile } from "../types";
+import { WELLPING_PREFIX } from "./asyncStorage";
+
+const STUDY_FILE_KEY = `${WELLPING_PREFIX}currentStudyFile`;
+
+export async function storeCurrentStudyFileAsync(studyFile: StudyFile) {
+  try {
+    await AsyncStorage.setItem(STUDY_FILE_KEY, JSON.stringify(studyFile));
+  } catch (error) {
+    // Error saving data
+    logError(error);
+  }
+}
+
+export async function getCurrentStudyFileAsync(): Promise<StudyFile | null> {
+  try {
+    const value = await AsyncStorage.getItem(STUDY_FILE_KEY);
+    if (value == null) {
+      return null;
+    }
+    const studyFile: StudyFile = parseJsonToStudyFile(value);
+    return studyFile;
+  } catch (error) {
+    // Error retrieving data
+    logError(error);
+    return null;
+  }
+}

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -21,7 +21,7 @@ export async function getCurrentStudyFileAsync(): Promise<StudyFile | null> {
     if (value == null) {
       return null;
     }
-    const studyFile: StudyFile = parseJsonToStudyFile(value);
+    const studyFile: StudyFile = parseJsonToStudyFile(JSON.parse(value));
     return studyFile;
   } catch (error) {
     // Error retrieving data

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -60,17 +60,3 @@ export async function getCurrentStreamsAsync(): Promise<Streams | null> {
     return null;
   }
 }
-
-export async function studyFileExistsAsync() {
-  const currentStudyInfo = await getCurrentStudyInfoAsync();
-  if (currentStudyInfo === null) {
-    return false;
-  }
-
-  const currentStreams = await getCurrentStreamsAsync();
-  if (currentStreams === null) {
-    return false;
-  }
-
-  return true;
-}

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -3,9 +3,8 @@ import { AsyncStorage } from "react-native";
 import { logError } from "../debug";
 import { parseJsonToStudyFile } from "../schemas/StudyFile";
 import { StudyFile } from "../types";
-import { WELLPING_PREFIX } from "./asyncStorage";
 
-const STUDY_FILE_KEY = `${WELLPING_PREFIX}currentStudyFile`;
+const STUDY_FILE_KEY = `currentStudyFile`;
 
 export async function storeCurrentStudyFileAsync(studyFile: StudyFile) {
   try {

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -15,6 +15,15 @@ export async function storeCurrentStudyFileAsync(studyFile: StudyFile) {
   }
 }
 
+export async function clearCurrentStudyFileAsync() {
+  try {
+    await AsyncStorage.removeItem(STUDY_FILE_KEY);
+  } catch (error) {
+    // Error saving data
+    logError(error);
+  }
+}
+
 export async function getCurrentStudyFileAsync(): Promise<StudyFile | null> {
   try {
     const value = await AsyncStorage.getItem(STUDY_FILE_KEY);

--- a/src/helpers/configFiles.ts
+++ b/src/helpers/configFiles.ts
@@ -4,7 +4,7 @@ import { getCriticalProblemTextForUser } from "./debug";
 import { parseJsonToStudyFile } from "./schemas/StudyFile";
 import { StudyFile, Names, StudyInfo, StreamName } from "./types";
 
-export async function getSurveyFileAsync(): Promise<StudyFile> {
+export async function getStudyFileAsync(): Promise<StudyFile> {
   const survey = require("../../config/survey.json");
 
   return parseJsonToStudyFile(survey);
@@ -15,7 +15,7 @@ export async function getSurveyFileAsync(): Promise<StudyFile> {
   } catch (e) {
     console.warn("Your study file has problem:");
     console.warn(e.message);
-    alert(getCriticalProblemTextForUser("getSurveyFileAsync"));
+    alert(getCriticalProblemTextForUser("getStudyFileAsync"));
   }*/
 }
 
@@ -29,7 +29,7 @@ export function getAllStreamNames(survey: StudyFile): StreamName[] {
   return Object.keys(survey.meta.startingQuestionIds) as StreamName[];
 }
 export async function getAllStreamNamesAsync(): Promise<StreamName[]> {
-  return getAllStreamNames(await getSurveyFileAsync());
+  return getAllStreamNames(await getStudyFileAsync());
 }
 
 export function isTimeThisWeek(time: Date, studyInfo: StudyInfo): boolean {
@@ -38,5 +38,5 @@ export function isTimeThisWeek(time: Date, studyInfo: StudyInfo): boolean {
   });
 }
 export async function isTimeThisWeekAsync(time: Date): Promise<boolean> {
-  return isTimeThisWeek(time, (await getSurveyFileAsync()).studyInfo);
+  return isTimeThisWeek(time, (await getStudyFileAsync()).studyInfo);
 }

--- a/src/helpers/configFiles.ts
+++ b/src/helpers/configFiles.ts
@@ -4,12 +4,28 @@ import { _DEBUG_CONFIGS } from "../../config/debug";
 import {
   storeCurrentStudyFileAsync,
   clearCurrentStudyFileAsync,
-  studyFileExistsAsync,
   getCurrentStudyInfoAsync,
   getCurrentStreamsAsync,
 } from "./asyncStorage/studyFile";
 import { parseJsonToStudyFile } from "./schemas/StudyFile";
 import { StudyFile, Names, StudyInfo, StreamName, Streams } from "./types";
+
+/**
+ * Returns whether of not the study file is stored locally.
+ */
+export async function studyFileExistsAsync() {
+  const currentStudyInfo = await getCurrentStudyInfoAsync();
+  if (currentStudyInfo === null) {
+    return false;
+  }
+
+  const currentStreams = await getCurrentStreamsAsync();
+  if (currentStreams === null) {
+    return false;
+  }
+
+  return true;
+}
 
 /**
  * Returns whether the study file should be downloaded (or redownloaded if

--- a/src/helpers/configFiles.ts
+++ b/src/helpers/configFiles.ts
@@ -1,22 +1,59 @@
 import { isThisWeek } from "date-fns";
 
-import { getCriticalProblemTextForUser } from "./debug";
+import {
+  getCurrentStudyFileAsync,
+  storeCurrentStudyFileAsync,
+} from "./asyncStorage/studyFile";
 import { parseJsonToStudyFile } from "./schemas/StudyFile";
 import { StudyFile, Names, StudyInfo, StreamName } from "./types";
 
-export async function getStudyFileAsync(): Promise<StudyFile> {
-  const survey = require("../../config/survey.json");
+/**
+ * Returns whether the study file should be downloaded (or redownloaded if
+ * already exists).
+ */
+export async function shouldDownloadStudyFileAsync(): Promise<boolean> {
+  const currentStudyFile = await getCurrentStudyFileAsync();
+  if (currentStudyFile === null) {
+    return true;
+  }
+  // TODO: MAYBE ADD A FIELD IN STUDY INFO SUCH THAT WE WILL FETCH THAT URL
+  // TO CHECK MD5 TO DETERMINE IF THE FILE SHOULD BE REDOWNLOADED.
+  return false;
+}
 
-  return parseJsonToStudyFile(survey);
-  /*try {
-    const survey = require("../../config/survey.json");
+/**
+ * Downloads a study file (in JSON format) from `url`.
+ * If the study file is successfully downloaded, parsed, and stored, stores
+ * the downloaded study file in Async Storage.
+ * Returns `null` if the whole process is successful.
+ * Returns the error message if any part of the process is unsuccessful.
+ */
+export async function downloadStudyFileAsync(
+  url: string,
+): Promise<string | null> {
+  try {
+    // TODO: ACTUAL DOWNLOAD PROCESS.
+    const study = require("../../config/survey.json");
 
-    return parseJsonToStudyFile(survey);
+    const parsedStudy = parseJsonToStudyFile(study);
+    await storeCurrentStudyFileAsync(parsedStudy);
+    return null;
   } catch (e) {
-    console.warn("Your study file has problem:");
-    console.warn(e.message);
-    alert(getCriticalProblemTextForUser("getStudyFileAsync"));
-  }*/
+    return e.message;
+  }
+}
+
+/**
+ * Returns the current study file.
+ * Throws an error if there isn't any current study file stored.
+ */
+export async function getStudyFileAsync(): Promise<StudyFile> {
+  const currentStudyFile = await getCurrentStudyFileAsync();
+  if (currentStudyFile === null) {
+    throw new Error("getCurrentStudyFileAsync = null");
+  }
+
+  return currentStudyFile;
 }
 
 // TODO: DECOUPLE FUNCTIONS LIKE THIS

--- a/src/helpers/configFiles.ts
+++ b/src/helpers/configFiles.ts
@@ -75,7 +75,9 @@ export async function getNamesFileAsync(): Promise<Names> {
 }
 
 export function getAllStreamNames(survey: StudyFile): StreamName[] {
-  return Object.keys(survey.meta.startingQuestionIds) as StreamName[];
+  return Object.keys(
+    survey.studyInfo.streamsStartingQuestionIds,
+  ) as StreamName[];
 }
 export async function getAllStreamNamesAsync(): Promise<StreamName[]> {
   return getAllStreamNames(await getStudyFileAsync());

--- a/src/helpers/configFiles.ts
+++ b/src/helpers/configFiles.ts
@@ -113,6 +113,7 @@ export async function getStudyFileAsync(): Promise<StudyFile> {
 }
 
 // TODO: DECOUPLE FUNCTIONS LIKE THIS
+// MAYBE AN EXTRA FIELD IN StudyFile to be { studyInfo, extra: { choices: { key: [...] } }, streams }
 export async function getNamesFileAsync(): Promise<Names> {
   const names: Names = require("../../config/names.json");
   return names;

--- a/src/helpers/debug.ts
+++ b/src/helpers/debug.ts
@@ -1,3 +1,7 @@
+import { Share } from "react-native";
+
+export const VERSION_NUMBER = "1.1.0";
+
 export function logError(error: any) {
   console.error(error);
 }
@@ -12,4 +16,14 @@ export function getNonCriticalProblemTextForUser(problem: string) {
 
 export function getCriticalProblemTextForUser(problem: string) {
   return `[CRITICAL ERROR (Please screenshot this page and send it to the study staff as soon as possible): ${problem}]`;
+}
+
+export function getUsefulDebugInfo(): string {
+  return `Version: ${VERSION_NUMBER}`;
+}
+
+export function shareDebugText(debugText: string) {
+  Share.share({
+    message: `${debugText}\n\n====\n${getUsefulDebugInfo()}`,
+  });
 }

--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -19,7 +19,7 @@ import {
   getNotificationTimesAsync,
   storeNotificationTimesAsync,
 } from "./asyncStorage/notificationTimes";
-import { isTimeThisWeekAsync, getSurveyFileAsync } from "./configFiles";
+import { isTimeThisWeekAsync } from "./configFiles";
 import { getThisWeekPingsAsync } from "./pings";
 import { StudyInfo } from "./types";
 

--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -19,9 +19,8 @@ import {
   getNotificationTimesAsync,
   storeNotificationTimesAsync,
 } from "./asyncStorage/notificationTimes";
-import { isTimeThisWeekAsync, getStudyInfoAsync } from "./configFiles";
 import { getThisWeekPingsAsync } from "./pings";
-import { StudyInfo } from "./types";
+import { isTimeThisWeekAsync, getStudyInfoAsync } from "./studyFile";
 
 const ANDROID_CHANNEL_NAME = "ssnlPingChannel";
 

--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -19,7 +19,7 @@ import {
   getNotificationTimesAsync,
   storeNotificationTimesAsync,
 } from "./asyncStorage/notificationTimes";
-import { isTimeThisWeekAsync } from "./configFiles";
+import { isTimeThisWeekAsync, getStudyInfoAsync } from "./configFiles";
 import { getThisWeekPingsAsync } from "./pings";
 import { StudyInfo } from "./types";
 
@@ -58,7 +58,9 @@ export async function setupNotificationsPermissionAsync(): Promise<boolean> {
   }
 }
 
-export async function setNotificationsAsync(studyInfo: StudyInfo) {
+export async function setNotificationsAsync() {
+  const studyInfo = await getStudyInfoAsync();
+
   await Notifications.cancelAllScheduledNotificationsAsync();
 
   const hoursEveryday = studyInfo.frequency.hoursEveryday;
@@ -195,15 +197,15 @@ export async function setNotificationsAsync(studyInfo: StudyInfo) {
 }
 
 // If `null` is returned, it means that currently there's no active ping.
-export async function getCurrentNotificationTimeAsync(
-  studyInfo: StudyInfo,
-): Promise<Date | null> {
+export async function getCurrentNotificationTimeAsync(): Promise<Date | null> {
   // DEBUG
   /* istanbul ignore if */
   if (__DEV__ && _DEBUG_CONFIGS().ignoreNotificationTime) {
     const fakeNotificationTime = addMinutes(new Date(), -10);
     return fakeNotificationTime;
   }
+
+  const studyInfo = await getStudyInfoAsync();
 
   const notificationsTimes = (await getNotificationTimesAsync()) || [];
 

--- a/src/helpers/pings.ts
+++ b/src/helpers/pings.ts
@@ -1,7 +1,7 @@
-import { isToday, addDays } from "date-fns";
+import { isToday } from "date-fns";
 
 import { PingEntity } from "../entities/PingEntity";
-import { isTimeThisWeekAsync } from "./configFiles";
+import { isTimeThisWeekAsync } from "./studyFile";
 import { StreamName } from "./types";
 
 export async function getNumberOfPingsForStreamName(

--- a/src/helpers/schemas/Stream.ts
+++ b/src/helpers/schemas/Stream.ts
@@ -5,6 +5,4 @@ import { QuestionIdSchema } from "./common";
 
 export const StreamsSchema = z.record(QuestionsListSchema);
 
-export const StreamsMetaSchema = z.object({
-  startingQuestionIds: z.record(QuestionIdSchema),
-});
+export const StreamsStartingQuestionIdsSchema = z.record(QuestionIdSchema);

--- a/src/helpers/schemas/Stream.ts
+++ b/src/helpers/schemas/Stream.ts
@@ -1,8 +1,13 @@
 import * as z from "zod";
 
+import { Streams } from "../types";
 import { QuestionsListSchema } from "./Question";
 import { QuestionIdSchema } from "./common";
 
 export const StreamsSchema = z.record(QuestionsListSchema);
 
 export const StreamsStartingQuestionIdsSchema = z.record(QuestionIdSchema);
+
+export function parseJsonToStreams(rawJson: any): Streams {
+  return StreamsSchema.parse(rawJson);
+}

--- a/src/helpers/schemas/StudyFile.ts
+++ b/src/helpers/schemas/StudyFile.ts
@@ -216,21 +216,23 @@ export const StudyFileSchema = z.object({
   streams: StreamsSchema,
 });
 
-export function parseJsonToStudyInfo(rawJson: any): StudyInfo {
+// https://stackoverflow.com/a/13104500/2603230
+const convertSpecialTypesInStudyInfo = (studyInfoRawJson: any) => {
   // We have to parse the dates as JSON stores dates as strings.
-  if (rawJson?.startDate) {
-    rawJson.startDate = parseJSON(rawJson.startDate);
+  if (studyInfoRawJson?.startDate) {
+    studyInfoRawJson.startDate = parseJSON(studyInfoRawJson.startDate);
   }
-  if (rawJson?.endDate) {
-    rawJson.endDate = parseJSON(rawJson.endDate);
+  if (studyInfoRawJson?.endDate) {
+    studyInfoRawJson.endDate = parseJSON(studyInfoRawJson.endDate);
   }
+};
+
+export function parseJsonToStudyInfo(rawJson: any): StudyInfo {
+  convertSpecialTypesInStudyInfo(rawJson);
   return StudyInfoSchema.parse(rawJson);
 }
 
 export function parseJsonToStudyFile(rawJson: any): StudyFile {
-  // We have to parse the dates as JSON stores dates as strings.
-  if (rawJson.studyInfo) {
-    rawJson.studyInfo = parseJsonToStudyInfo(rawJson.studyInfo);
-  }
+  convertSpecialTypesInStudyInfo(rawJson?.studyInfo);
   return StudyFileSchema.parse(rawJson);
 }

--- a/src/helpers/schemas/StudyFile.ts
+++ b/src/helpers/schemas/StudyFile.ts
@@ -1,7 +1,7 @@
 import { parseJSON } from "date-fns";
 import * as z from "zod";
 
-import { StudyFile } from "../types";
+import { StudyFile, StudyInfo } from "../types";
 import { StreamsSchema, StreamsStartingQuestionIdsSchema } from "./Stream";
 import { StudyIdSchema, StreamNameSchema } from "./common";
 
@@ -216,13 +216,21 @@ export const StudyFileSchema = z.object({
   streams: StreamsSchema,
 });
 
+export function parseJsonToStudyInfo(rawJson: any): StudyInfo {
+  // We have to parse the dates as JSON stores dates as strings.
+  if (rawJson?.startDate) {
+    rawJson.startDate = parseJSON(rawJson.startDate);
+  }
+  if (rawJson?.endDate) {
+    rawJson.endDate = parseJSON(rawJson.endDate);
+  }
+  return StudyInfoSchema.parse(rawJson);
+}
+
 export function parseJsonToStudyFile(rawJson: any): StudyFile {
   // We have to parse the dates as JSON stores dates as strings.
-  if (rawJson.studyInfo?.startDate) {
-    rawJson.studyInfo.startDate = parseJSON(rawJson.studyInfo.startDate);
-  }
-  if (rawJson.studyInfo?.endDate) {
-    rawJson.studyInfo.endDate = parseJSON(rawJson.studyInfo.endDate);
+  if (rawJson.studyInfo) {
+    rawJson.studyInfo = parseJsonToStudyInfo(rawJson.studyInfo);
   }
   return StudyFileSchema.parse(rawJson);
 }

--- a/src/helpers/schemas/StudyFile.ts
+++ b/src/helpers/schemas/StudyFile.ts
@@ -2,7 +2,7 @@ import { parseJSON } from "date-fns";
 import * as z from "zod";
 
 import { StudyFile } from "../types";
-import { StreamsSchema, StreamsMetaSchema } from "./Stream";
+import { StreamsSchema, StreamsStartingQuestionIdsSchema } from "./Stream";
 import { StudyIdSchema, StreamNameSchema } from "./common";
 
 export const WeekStartsOnSchema = z.union([
@@ -117,6 +117,11 @@ export const StudyInfoSchema = z
     }),
 
     /**
+     * The question ID of the first question of each stream.
+     */
+    streamsStartingQuestionIds: StreamsStartingQuestionIdsSchema,
+
+    /**
      * The streams that the user will fill (in this order) every day.
      *
      * For example, if `streamsOrder[0]` is `["dog", "cat", "wolf", "lynx"]`,
@@ -208,7 +213,6 @@ export const StudyInfoSchema = z
 
 export const StudyFileSchema = z.object({
   studyInfo: StudyInfoSchema,
-  meta: StreamsMetaSchema,
   streams: StreamsSchema,
 });
 

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -55,6 +55,7 @@ export async function downloadStudyFileAsync(
   url: string,
 ): Promise<string | null> {
   try {
+    // TODO: PROBABLY CHECK E.G. IF `url` == "__WELLPING_LOCAL__", then load this local config
     // TODO: ACTUAL DOWNLOAD PROCESS.
     const study = require("../../config/survey.json");
 

--- a/src/questionScreens/MultipleTextQuestionScreen.tsx
+++ b/src/questionScreens/MultipleTextQuestionScreen.tsx
@@ -7,8 +7,7 @@ import {
   QuestionScreenProps,
   MultipleTextAnswerData,
 } from "../helpers/answerTypes";
-import { getNamesFileAsync } from "../helpers/configFiles";
-import { withVariable } from "../helpers/helpers";
+import { getNamesFileAsync } from "../helpers/studyFile";
 import { MultipleTextQuestion, Names } from "../helpers/types";
 // @ts-ignore
 import SearchableDropdown from "../inc/react-native-searchable-dropdown";


### PR DESCRIPTION
- Store `StudyFile` (i.e., `StudyInfo` & `Streams`) in Async Storage.
  - `StudyInfo` and `Streams` are stored separately (i.e., there isn't a Async Storage key storing `StudyFile`). It is because `StudyInfo` is usually more frequently used and tends to be smaller than `Streams`. Storing them separately probably could improve performance.
- Preparing for support downloading study file JSON.
- Created an error screen to show problems related to the survey file.
- Moved `meta.startingQuestionIds` to `studyInfo.streamsStartingQuestionIds`.
- Created `mockCurrentStudyInfo` helper function to help testing.
- Removed the confusing `studyInfo` parameter in `setNotificationsAsync` and `getCurrentNotificationTimeAsync`.
  - These functions will get study info directly from the `getStudyInfoAsync()` function.

Part of https://github.com/StanfordSocialNeuroscienceLab/WellPing/issues/3 and https://github.com/StanfordSocialNeuroscienceLab/WellPing/issues/11.