### PR TITLE
Allow using arbitrary JSON study file; Use Base64 magic login code to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ A survey app that pings you once a while to answer questions!
 ## Docs
 - [Supported Question Types](https://github.com/StanfordSocialNeuroscienceLab/WellPing/wiki/Supported-Question-Types)
 
+## Demo
+Login with the magic login code 🧙‍♀️:
+```
+ewoJInVzZXJuYW1lIjogIl9fZGVidWdfXyIsCgkicGFzc3dvcmQiOiAiX190ZXN0X18iLAoJInN0dWR5RmlsZUpzb25VcmwiOiAiaHR0cHM6Ly93ZWxscGluZ19sb2NhbF9fLnNzbmwuc3RhbmZvcmQuZWR1L2RlYnVnLmpzb24iCn0=
+```
+
+In case you are wondering, it's just the Base64 encoding of this:
+```json
+{
+	"username": "__debug__",
+	"password": "__test__",
+	"studyFileJsonUrl": "https://wellping_local__.ssnl.stanford.edu/debug.json"
+}
+```
+
+This access the local study file "config/survey.json".
+
 ## Development
 ```bash
 # Installation

--- a/config/debug.ts
+++ b/config/debug.ts
@@ -6,9 +6,9 @@
 
 export function _DEBUG_CONFIGS() {
   return {
-    ignoreLogin: true,
+    ignoreLogin: false,
     ignoreNotificationTime: true,
     showCurrentStatesInSurveyScreen: false,
-    alwaysRedownloadStudyFile: true,
+    alwaysRedownloadStudyFile: false,
   };
 }

--- a/config/debug.ts
+++ b/config/debug.ts
@@ -6,9 +6,7 @@
 
 export function _DEBUG_CONFIGS() {
   return {
-    ignoreLogin: false,
     ignoreNotificationTime: true,
     showCurrentStatesInSurveyScreen: false,
-    alwaysRedownloadStudyFile: false,
   };
 }

--- a/config/survey.json
+++ b/config/survey.json
@@ -2,7 +2,7 @@
   "studyInfo": {
     "id": "example_study",
     "studyFileJsonURL": "https://wellping_local__.ssnl.stanford.edu/debug.json",
-    "consentFormUrl": "https://www.example.com/consentform",
+    "consentFormUrl": "http://ssnl.stanford.edu/research",
     "contactEmail": "testEmail@example.com",
     "startDate": "2020-03-10T08:00:00.000Z",
     "endDate": "2020-04-25T08:00:00.000Z",
@@ -38,7 +38,7 @@
         "numberOfCompletionEachWeek": 10
       }
     },
-    "serverURL": "https://www.example.com/"
+    "serverURL": "http://ssnl.stanford.edu/"
   },
   "streams": {
     "myStream": {

--- a/config/survey.json
+++ b/config/survey.json
@@ -2,7 +2,7 @@
   "studyInfo": {
     "id": "example_study",
     "studyFileJsonURL": "https://wellping_local__.ssnl.stanford.edu/debug.json",
-    "consentFormUrl": "https://www.example.com/",
+    "consentFormUrl": "https://www.example.com/consentform",
     "contactEmail": "testEmail@example.com",
     "startDate": "2020-03-10T08:00:00.000Z",
     "endDate": "2020-04-25T08:00:00.000Z",
@@ -38,7 +38,7 @@
         "numberOfCompletionEachWeek": 10
       }
     },
-    "serverURL": "https://wellping.hesyifei.com/"
+    "serverURL": "https://www.example.com/"
   },
   "streams": {
     "myStream": {

--- a/config/survey.json
+++ b/config/survey.json
@@ -1,6 +1,7 @@
 {
   "studyInfo": {
     "id": "example_study",
+    "studyFileJsonURL": "https://wellping_local__.ssnl.stanford.edu/debug.json",
     "consentFormUrl": "https://www.example.com/",
     "contactEmail": "testEmail@example.com",
     "startDate": "2020-03-10T08:00:00.000Z",

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -8,7 +8,6 @@ import {
   View,
   ScrollView,
   Alert,
-  StyleSheet,
   Clipboard,
   Platform,
   TouchableWithoutFeedback,
@@ -61,16 +60,8 @@ import {
   getNumbersOfPingsForAllStreamNames,
 } from "./helpers/pings";
 import { getAllStreamNames, getStudyInfoAsync } from "./helpers/studyFile";
+import { styles } from "./helpers/styles";
 import { Streams, StreamName, StudyInfo } from "./helpers/types";
-
-const styles = StyleSheet.create({
-  onlyTextStyle: {
-    textAlign: "center",
-    marginTop: 30,
-    fontSize: 25,
-    marginHorizontal: 10,
-  },
-});
 
 interface HomeScreenProps {
   studyInfo: StudyInfo;

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -217,7 +217,7 @@ export default class RootScreen extends React.Component<
         margin: 15,
       };
       return (
-        <ScrollView>
+        <ScrollView style={{ height: "100%" }}>
           <View style={{ padding: 20 }}>
             <Text
               style={{ fontSize: 30, marginBottom: 20, textAlign: "center" }}

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -130,6 +130,11 @@ export default class RootScreen extends React.Component<
     }
   }
 
+  async logoutAsync() {
+    await clearUserAsync();
+    this.setState({ userInfo: null });
+  }
+
   render() {
     const {
       isLoading,
@@ -313,8 +318,7 @@ export default class RootScreen extends React.Component<
         studyInfo={this.state.survey.studyInfo}
         streams={this.state.survey.streams}
         logout={async () => {
-          await clearUserAsync();
-          this.setState({ userInfo: null });
+          await this.logoutAsync();
         }}
       />
     );

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -4,6 +4,12 @@ import { Button, TextInput, Text, View, ScrollView, Alert } from "react-native";
 
 import HomeScreen from "./HomeScreen";
 import { registerUserAsync } from "./helpers/apiManager";
+import { clearCurrentStudyFileAsync } from "./helpers/asyncStorage/studyFile";
+import {
+  storeTempStudyFileAsync,
+  getTempStudyFileAsync,
+  clearTempStudyFileAsync,
+} from "./helpers/asyncStorage/tempStudyFile";
 import {
   getUserAsync,
   User,
@@ -15,7 +21,7 @@ import {
   getStudyFileAsync,
   downloadStudyFileAsync,
   parseAndStoreStudyFileAsync,
-  shouldDownloadStudyFileAsync,
+  studyFileExistsAsync,
 } from "./helpers/studyFile";
 import { styles } from "./helpers/styles";
 import { StudyFile } from "./helpers/types";
@@ -48,6 +54,18 @@ export default class RootScreen extends React.Component<
     };
   }
 
+  async parseStudyFileAsync(rawJsonString: string): Promise<boolean> {
+    const parseErrorMessage = await parseAndStoreStudyFileAsync(rawJsonString);
+    if (parseErrorMessage !== null) {
+      this.setState({
+        isLoading: false,
+        studyFileErrorText: parseErrorMessage,
+      });
+      return false;
+    }
+    return true;
+  }
+
   /**
    * Returns `false` if the downloading or the parsing process is unsuccessful.
    * Returns `true` otherwise.
@@ -70,9 +88,9 @@ export default class RootScreen extends React.Component<
         } else {
           downloadErrorMessage = `Unknown error: ${e}`;
         }
-        alert("Download failed!");
+        alert("Failed to download study data! Please try again later.");
         this.setState({
-          errorText: `Download failed: ${downloadErrorMessage}`,
+          errorText: `Failed to download study data!\n\n${downloadErrorMessage}`,
         });
         return false;
       } else {
@@ -82,35 +100,61 @@ export default class RootScreen extends React.Component<
       }
     }
 
-    const parseErrorMessage = await parseAndStoreStudyFileAsync(rawJsonString);
-    if (parseErrorMessage !== null) {
-      this.setState({
-        studyFileErrorText: parseErrorMessage,
-      });
-      return false;
+    if (isRedownload) {
+      // Store it in temp storage first, parse it next time.
+      await storeTempStudyFileAsync(rawJsonString);
+      return true;
     }
-    return true;
+
+    return this.parseStudyFileAsync(rawJsonString);
+  }
+
+  /**
+   * Loads and parse the study file from the temp study file Async Storage.
+   * Returns `true` if there is no error (or no temp study file).
+   * Returns `false` otherwise.
+   */
+  async loadTempStudyFileAsync(): Promise<boolean> {
+    const tempStudyFile = await getTempStudyFileAsync();
+    if (tempStudyFile === null) {
+      return true;
+    }
+    // We have to `clearTempStudyFileAsync` before `parseStudyFileAsync`
+    // because if the new study info is invalid, `parseStudyFileAsync` clears
+    // study info which `clearTempStudyFileAsync` needs.
+    await clearTempStudyFileAsync();
+    const results = await this.parseStudyFileAsync(tempStudyFile);
+    return results;
   }
 
   async componentDidMount() {
-    const user = await getUserAsync();
-    if (user) {
-      if (await shouldDownloadStudyFileAsync()) {
-        if (!(await this.downloadAndParseStudyFileAsync("TODO: ", true))) {
-          this.setState({ isLoading: false });
-          return;
-        }
+    if (await studyFileExistsAsync()) {
+      if (!(await this.loadTempStudyFileAsync())) {
+        return;
       }
 
       const survey = await getStudyFileAsync();
 
+      // Do it in background because there isn't any urgency to redownload.
+      this.downloadAndParseStudyFileAsync(
+        survey.studyInfo.studyFileJsonURL,
+        true,
+      );
+
+      const user = await getUserAsync();
+      if (user === null) {
+        // This will happen when e.g., the study file is downloads but the user
+        // didn't successfully login.
+        await this.logoutAsync();
+        this.setState({ isLoading: false });
+        return;
+      }
+
       await connectDatabaseAsync(survey.studyInfo.id);
 
-      this.setState({ survey });
-    }
-    this.setState({ userInfo: user, isLoading: false });
-
-    if (user == null) {
+      this.setState({ userInfo: user, survey });
+    } else {
+      // New user.
       Alert.alert(
         "Confirm",
         `Are you at least 18 years of age?`,
@@ -128,10 +172,13 @@ export default class RootScreen extends React.Component<
         { cancelable: false },
       );
     }
+
+    this.setState({ isLoading: false });
   }
 
   async logoutAsync() {
     await clearUserAsync();
+    await clearCurrentStudyFileAsync();
     this.setState({ userInfo: null });
   }
 
@@ -249,7 +296,21 @@ export default class RootScreen extends React.Component<
             title="Log in"
             onPress={async () => {
               this.setState({
-                errorText: "Loading...",
+                errorText: "Loading study data...",
+              });
+
+              if (
+                !(await this.downloadAndParseStudyFileAsync(
+                  "https://wellping_local__.ssnl.stanford.edu/debug.json",
+                ))
+              ) {
+                return;
+              }
+
+              const survey = await getStudyFileAsync();
+
+              this.setState({
+                errorText: "Authenticating...",
               });
 
               const user: User = {
@@ -265,21 +326,12 @@ export default class RootScreen extends React.Component<
                     {
                       text: "Review",
                       onPress: async () => {
-                        this.setState({
-                          errorText: "Downloading study data...",
-                        });
-
-                        if (
-                          !(await this.downloadAndParseStudyFileAsync("TODO: "))
-                        ) {
-                          return;
-                        }
-
-                        const survey = await getStudyFileAsync();
-
                         await WebBrowser.openBrowserAsync(
                           survey.studyInfo.consentFormUrl,
                         );
+
+                        // Because database was not previously connected.
+                        await connectDatabaseAsync(survey.studyInfo.id);
 
                         this.setState({
                           userInfo: user,

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -63,9 +63,15 @@ export default class RootScreen extends React.Component<
       rawJsonString = await downloadStudyFileAsync(url);
     } catch (e) {
       if (!isRedownload) {
+        let downloadErrorMessage: string;
+        if (e instanceof Error) {
+          downloadErrorMessage = `**${e.name}**\n${e.message}`;
+        } else {
+          downloadErrorMessage = `Unknown error: ${e}`;
+        }
         alert("Download failed!");
         this.setState({
-          errorText: `Download failed: ${e}`,
+          errorText: `Download failed: ${downloadErrorMessage}`,
         });
         return false;
       } else {
@@ -75,10 +81,10 @@ export default class RootScreen extends React.Component<
       }
     }
 
-    const parseError = await parseAndStoreStudyFileAsync(rawJsonString);
-    if (parseError !== null) {
+    const parseErrorMessage = await parseAndStoreStudyFileAsync(rawJsonString);
+    if (parseErrorMessage !== null) {
       this.setState({
-        studyFileErrorText: parseError,
+        studyFileErrorText: parseErrorMessage,
       });
       return false;
     }

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -17,6 +17,7 @@ import {
   parseAndStoreStudyFileAsync,
   shouldDownloadStudyFileAsync,
 } from "./helpers/studyFile";
+import { styles } from "./helpers/styles";
 import { StudyFile } from "./helpers/types";
 
 interface RootScreenProps {}
@@ -140,7 +141,7 @@ export default class RootScreen extends React.Component<
     if (isLoading) {
       return (
         <View>
-          <Text>Loading...</Text>
+          <Text style={styles.onlyTextStyle}>Loading...</Text>
         </View>
       );
     }

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -41,6 +41,7 @@ interface RootScreenState {
   userInfo: User | null;
   isLoading: boolean;
   formData?: string;
+  disableLoginButton: boolean;
   errorText: string | null;
   studyFileErrorText: string | null;
   unableToParticipate?: boolean;
@@ -57,6 +58,7 @@ export default class RootScreen extends React.Component<
     this.state = {
       userInfo: null,
       isLoading: true,
+      disableLoginButton: false,
       errorText: null,
       studyFileErrorText: null,
     };
@@ -286,6 +288,7 @@ export default class RootScreen extends React.Component<
             autoCompleteType="off"
             placeholder="Paste your magic login code here..."
             multiline
+            editable={!this.state.disableLoginButton}
             style={{
               padding: 8,
               borderWidth: 1,
@@ -297,8 +300,10 @@ export default class RootScreen extends React.Component<
           />
           <Button
             title="Log in"
+            disabled={this.state.disableLoginButton}
             onPress={async () => {
               this.setState({
+                disableLoginButton: true,
                 errorText: "Magical things happening... 🧙‍♂️",
               });
 
@@ -329,6 +334,7 @@ export default class RootScreen extends React.Component<
                 studyFileJsonUrl = loginInfo.studyFileJsonUrl;
               } catch (e) {
                 this.setState({
+                  disableLoginButton: false,
                   errorText:
                     "Your magic login code is invalid 😕. Please screenshot " +
                     "the current page and contact the research staff.\n\n" +
@@ -344,6 +350,7 @@ export default class RootScreen extends React.Component<
               if (
                 !(await this.downloadAndParseStudyFileAsync(studyFileJsonUrl))
               ) {
+                this.setState({ disableLoginButton: false });
                 return;
               }
 
@@ -373,6 +380,7 @@ export default class RootScreen extends React.Component<
                           userInfo: user,
                           survey,
                           errorText: null,
+                          disableLoginButton: false,
                         });
                       },
                     },
@@ -382,6 +390,7 @@ export default class RootScreen extends React.Component<
               } else {
                 this.setState({
                   errorText: error,
+                  disableLoginButton: false,
                 });
               }
             }}

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -298,6 +298,10 @@ export default class RootScreen extends React.Component<
           <Button
             title="Log in"
             onPress={async () => {
+              this.setState({
+                errorText: "Magical things happening... 🧙‍♂️",
+              });
+
               Keyboard.dismiss();
 
               let user!: User;
@@ -334,7 +338,7 @@ export default class RootScreen extends React.Component<
               }
 
               this.setState({
-                errorText: "Loading study data...",
+                errorText: "Loading study data... ☁️",
               });
 
               if (
@@ -346,7 +350,7 @@ export default class RootScreen extends React.Component<
               const survey = await getStudyFileAsync();
 
               this.setState({
-                errorText: "Authenticating...",
+                errorText: "Authenticating... 🤖",
               });
 
               const error = await registerUserAsync(user);

--- a/src/helpers/apiManager.ts
+++ b/src/helpers/apiManager.ts
@@ -8,7 +8,7 @@ import { PingEntity } from "../entities/PingEntity";
 import { getAnswersAsync } from "./answers";
 import { User, storeUserAsync, getUserAsync } from "./asyncStorage/user";
 import { getPingsAsync } from "./pings";
-import { getStudyInfoAsync } from "./studyFile";
+import { getStudyInfoAsync, isLocalStudyFile } from "./studyFile";
 
 export async function getServerUrlAsync(): Promise<string> {
   return (await getStudyInfoAsync()).serverURL;
@@ -127,6 +127,12 @@ export async function makePostRequestAsync(
   body?: { [key: string]: any },
   user?: User,
 ): Promise<any> {
+  if (isLocalStudyFile()) {
+    // Always return successful response if it is a local study file.
+    await new Promise((r) => setTimeout(r, 3000)); // Simulate loading.
+    return {};
+  }
+
   const headers = {
     "Beiwe-Api-Version": "2",
     Accept: "application/vnd.beiwe.api.v2, application/json",
@@ -143,8 +149,6 @@ export async function makePostRequestAsync(
   });
 
   if (response.status < 200 || response.status >= 400) {
-    console.warn(`ERRORREQUEST: ${JSON.stringify(response)}`);
-
     if (response.status === 401 || response.status === 403) {
       throw new Error(
         `Verification failed.\n\nRequest: ${JSON.stringify(

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -40,7 +40,8 @@ export async function getCurrentStudyInfoAsync(): Promise<StudyInfo | null> {
     const studyInfo: StudyInfo = parseJsonToStudyInfo(JSON.parse(value));
     return studyInfo;
   } catch (error) {
-    // Error retrieving data
+    // We don't want this ill-formatted study file to be stored.
+    await clearCurrentStudyFileAsync();
     logError(error);
     return null;
   }
@@ -55,7 +56,8 @@ export async function getCurrentStreamsAsync(): Promise<Streams | null> {
     const streams: Streams = parseJsonToStreams(JSON.parse(value));
     return streams;
   } catch (error) {
-    // Error retrieving data
+    // We don't want this ill-formatted study file to be stored.
+    await clearCurrentStudyFileAsync();
     logError(error);
     return null;
   }

--- a/src/helpers/asyncStorage/tempStudyFile.ts
+++ b/src/helpers/asyncStorage/tempStudyFile.ts
@@ -1,0 +1,51 @@
+/**
+ * The study file is downloaded from the studyFileJsonUrl at every start in the
+ * background.
+ * This stores the downloaded file, which will be loaded (and replace the normal
+ * study file) at the next start.
+ * This is so that the downloaded file will not interfere with the user in the
+ * middle of some process.
+ */
+import { AsyncStorage } from "react-native";
+
+import { logError } from "../debug";
+import { getASKeyAsync } from "./asyncStorage";
+
+const TEMP_STUDY_FILE = `tempStudyFile`;
+
+export async function storeTempStudyFileAsync(responseString: string) {
+  try {
+    await AsyncStorage.setItem(
+      await getASKeyAsync(TEMP_STUDY_FILE),
+      responseString,
+    );
+  } catch (error) {
+    // Error saving data
+    logError(error);
+  }
+}
+
+export async function clearTempStudyFileAsync() {
+  try {
+    await AsyncStorage.removeItem(await getASKeyAsync(TEMP_STUDY_FILE));
+  } catch (error) {
+    // Error saving data
+    logError(error);
+  }
+}
+
+export async function getTempStudyFileAsync(): Promise<string | null> {
+  try {
+    const value = await AsyncStorage.getItem(
+      await getASKeyAsync(TEMP_STUDY_FILE),
+    );
+    if (value == null) {
+      return null;
+    }
+    return value;
+  } catch (error) {
+    // Error retrieving data
+    logError(error);
+    return null;
+  }
+}

--- a/src/helpers/asyncStorage/user.ts
+++ b/src/helpers/asyncStorage/user.ts
@@ -33,14 +33,6 @@ export async function clearUserAsync() {
 }
 
 export async function getUserAsync(): Promise<User | null> {
-  // DEBUG
-  if (__DEV__ && _DEBUG_CONFIGS().ignoreLogin) {
-    return {
-      patientId: "_DEBUGGING_USERNAME_",
-      password: "_DEBUGGING_PASSWORD_",
-    };
-  }
-
   try {
     const value = await AsyncStorage.getItem(await getASKeyAsync(USER_KEY));
     if (value == null) {

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -1,6 +1,6 @@
 import * as FileSystem from "expo-file-system";
 import { Share } from "react-native";
-import { createConnection, Connection } from "typeorm";
+import { createConnection, Connection, getConnection } from "typeorm";
 
 import {
   AnswerEntity,
@@ -29,14 +29,18 @@ export const entities = [
 export async function connectDatabaseAsync(
   databaseName: string,
 ): Promise<Connection> {
-  return await createConnection({
-    type: "expo",
-    driver: require("expo-sqlite"),
-    database: getDatabaseFilename(databaseName),
-    entities,
-    synchronize: true,
-    logging: true,
-  });
+  try {
+    return getConnection();
+  } catch {
+    return await createConnection({
+      type: "expo",
+      driver: require("expo-sqlite"),
+      database: getDatabaseFilename(databaseName),
+      entities,
+      synchronize: true,
+      logging: true,
+    });
+  }
 }
 
 export function getDatabaseFileUrl(databaseName: string): string {

--- a/src/helpers/schemas/Login.ts
+++ b/src/helpers/schemas/Login.ts
@@ -1,0 +1,7 @@
+import * as z from "zod";
+
+export const LoginSchema = z.object({
+  username: z.string().nonempty(),
+  password: z.string().nonempty(),
+  studyFileJsonUrl: z.string().url().nonempty(),
+});

--- a/src/helpers/schemas/StudyFile.ts
+++ b/src/helpers/schemas/StudyFile.ts
@@ -25,6 +25,13 @@ export const StudyInfoSchema = z
     id: StudyIdSchema,
 
     /**
+     * The URL that host this study file. The app fetches this URL in the
+     * background at every start and loads the downloaded new file at the
+     * next start.
+     */
+    studyFileJsonURL: z.string().url(),
+
+    /**
      * The server URL (including the trailing slash).
      */
     serverURL: z.string().url(),

--- a/src/helpers/schemas/StudyFile.ts
+++ b/src/helpers/schemas/StudyFile.ts
@@ -217,6 +217,7 @@ export const StudyInfoSchema = z
         "to the length of `frequency.hoursEveryday`.",
     },
   );
+// TODO: refine don't allow USE IT WHEN NEW DATE() IS AFTER THE ENDDATE.
 
 export const StudyFileSchema = z.object({
   studyInfo: StudyInfoSchema,

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -46,20 +46,29 @@ export async function shouldDownloadStudyFileAsync(): Promise<boolean> {
 
 /**
  * Downloads a study file (in JSON format) from `url`.
- * If the study file is successfully downloaded, parsed, and stored, stores
- * the downloaded study file in Async Storage.
- * Returns `null` if the whole process is successful.
- * Returns the error message if any part of the process is unsuccessful.
+ * Returns the content of the file (as a string).
+ * Throws an error if the download process failed.
  */
-export async function downloadStudyFileAsync(
-  url: string,
+export async function downloadStudyFileAsync(url: string): Promise<string> {
+  // TODO: PROBABLY CHECK E.G. IF `url` == "__WELLPING_LOCAL__", then load this local config
+  // TODO: ACTUAL DOWNLOAD PROCESS.
+  const rawJsonString = JSON.stringify(require("../../config/survey.json"));
+  return rawJsonString;
+}
+
+/**
+ * Parses a study file from `rawJsonString` (a string that can be parsed to a
+ * JSON object).
+ * If the study file is successfully parsed, stores the downloaded study file
+ * in Async Storage.
+ * Returns `null` if all processes are successful.
+ * Returns the error message if any process is unsuccessful.
+ */
+export async function parseAndStoreStudyFileAsync(
+  rawJsonString: string,
 ): Promise<string | null> {
   try {
-    // TODO: PROBABLY CHECK E.G. IF `url` == "__WELLPING_LOCAL__", then load this local config
-    // TODO: ACTUAL DOWNLOAD PROCESS.
-    const study = require("../../config/survey.json");
-
-    const parsedStudy = parseJsonToStudyFile(study);
+    const parsedStudy = parseJsonToStudyFile(JSON.parse(rawJsonString));
     await storeCurrentStudyFileAsync(parsedStudy);
     return null;
   } catch (e) {

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -24,6 +24,10 @@ export async function isLocalStudyFile(): Promise<boolean> {
  * Returns whether of not the study file is stored locally.
  */
 export async function studyFileExistsAsync() {
+  if (__DEV__ && _DEBUG_CONFIGS().alwaysRedownloadStudyFile) {
+    return false;
+  }
+
   const currentStudyInfo = await getCurrentStudyInfoAsync();
   if (currentStudyInfo === null) {
     return false;
@@ -35,23 +39,6 @@ export async function studyFileExistsAsync() {
   }
 
   return true;
-}
-
-/**
- * Returns whether the study file should be downloaded (or redownloaded if
- * already exists).
- */
-export async function shouldDownloadStudyFileAsync(): Promise<boolean> {
-  if (__DEV__ && _DEBUG_CONFIGS().alwaysRedownloadStudyFile) {
-    return true;
-  }
-
-  if (!(await studyFileExistsAsync())) {
-    return true;
-  }
-  // TODO: MAYBE ADD A FIELD IN STUDY INFO SUCH THAT WE WILL FETCH THAT URL
-  // TO CHECK MD5 TO DETERMINE IF THE FILE SHOULD BE REDOWNLOADED.
-  return false;
 }
 
 /**

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -10,6 +10,10 @@ import {
 import { parseJsonToStudyFile } from "./schemas/StudyFile";
 import { StudyFile, Names, StudyInfo, StreamName, Streams } from "./types";
 
+const WELLPING_LOCAL_DEBUG_URL =
+  "https://wellping_local__.ssnl.stanford.edu/debug.json";
+// TODO: const WELLPING_LOCAL_DEMO_URL = "https://wellping_local__.ssnl.stanford.edu/demo.json";
+
 /**
  * Returns whether of not the study file is stored locally.
  */

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -24,10 +24,6 @@ export async function isLocalStudyFile(): Promise<boolean> {
  * Returns whether of not the study file is stored locally.
  */
 export async function studyFileExistsAsync() {
-  if (__DEV__ && _DEBUG_CONFIGS().alwaysRedownloadStudyFile) {
-    return false;
-  }
-
   const currentStudyInfo = await getCurrentStudyInfoAsync();
   if (currentStudyInfo === null) {
     return false;

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -10,9 +10,15 @@ import {
 import { parseJsonToStudyFile } from "./schemas/StudyFile";
 import { StudyFile, Names, StudyInfo, StreamName, Streams } from "./types";
 
-const WELLPING_LOCAL_DEBUG_URL =
+export const WELLPING_LOCAL_DEBUG_URL =
   "https://wellping_local__.ssnl.stanford.edu/debug.json";
-// TODO: const WELLPING_LOCAL_DEMO_URL = "https://wellping_local__.ssnl.stanford.edu/demo.json";
+// TODO: export const WELLPING_LOCAL_DEMO_URL = "https://wellping_local__.ssnl.stanford.edu/demo.json";
+
+export async function isLocalStudyFile(): Promise<boolean> {
+  return (
+    (await getStudyInfoAsync()).studyFileJsonURL === WELLPING_LOCAL_DEBUG_URL
+  );
+}
 
 /**
  * Returns whether of not the study file is stored locally.
@@ -54,10 +60,26 @@ export async function shouldDownloadStudyFileAsync(): Promise<boolean> {
  * Throws an error if the download process failed.
  */
 export async function downloadStudyFileAsync(url: string): Promise<string> {
-  // TODO: PROBABLY CHECK E.G. IF `url` == "__WELLPING_LOCAL__", then load this local config
-  // TODO: ACTUAL DOWNLOAD PROCESS.
-  const rawJsonString = JSON.stringify(require("../../config/survey.json"));
-  return rawJsonString;
+  if (url === WELLPING_LOCAL_DEBUG_URL) {
+    await new Promise((r) => setTimeout(r, 3000)); // Simulate loading.
+    const rawJsonString = JSON.stringify(require("../../config/survey.json"));
+    return rawJsonString;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      cache: "no-cache",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    });
+
+    return response.text();
+  } catch (e) {
+    throw e;
+  }
 }
 
 /**

--- a/src/helpers/styles.ts
+++ b/src/helpers/styles.ts
@@ -1,0 +1,10 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  onlyTextStyle: {
+    textAlign: "center",
+    marginTop: 30,
+    fontSize: 25,
+    marginHorizontal: 10,
+  },
+});


### PR DESCRIPTION
- Add a `studyFileJsonURL` field to `studyInfo`.
- Add support to use arbitrary JSON study file.
  - On login, the app will download the JSON study file from the `studyFileJsonURL` field in the login info (`LoginSchema`), and then authenticate the user.
  - On each app launch, the app will try to fetch (asynchronously) a newer version of the study file from `studyInfo.studyFileJsonURL` and store it as temp study file. On the next launch, this temp study file replace the current one. This is so that the current study file will not change when the user is actively using the app.
  - A special URL (`https://wellping_local__.ssnl.stanford.edu/debug.json`) is set. If this URL is the `studyFileJsonURL`, the app will `require` the "config/survey.json" instead of finding a remote file. Additionally, no server request will be sent, and one can login with any non-empty username and password.
- The login screen has changed from username-password combination to "magic login code." This way the user doesn't need to go back and forth to copy three different values (username, password, and study file URL) to login. Instead, they can simply copy the whole chunk of characters and paste it in.
- Fix the problem that Typeorm will try to create new connection even though there is already a connection.

Resolves #3.