### PR TITLE
Use simpler login code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,12 @@ A survey app that pings you once a while to answer questions!
 - [Supported Question Types](https://github.com/StanfordSocialNeuroscienceLab/WellPing/wiki/Supported-Question-Types)
 
 ## Demo
-Login with the magic login code 🧙‍♀️:
+Log in with the login code
 ```
-ewoJInVzZXJuYW1lIjogIl9fZGVidWdfXyIsCgkicGFzc3dvcmQiOiAiX190ZXN0X18iLAoJInN0dWR5RmlsZUpzb25VcmwiOiAiaHR0cHM6Ly93ZWxscGluZ19sb2NhbF9fLnNzbmwuc3RhbmZvcmQuZWR1L2RlYnVnLmpzb24iCn0=
+__debug__ __test__ https://wellping_local__.ssnl.stanford.edu/debug.json
 ```
 
-In case you are wondering, it's just the Base64 encoding of this:
-```json
-{
-	"username": "__debug__",
-	"password": "__test__",
-	"studyFileJsonUrl": "https://wellping_local__.ssnl.stanford.edu/debug.json"
-}
-```
+Alternatively, click this link to log in: https://stanfordsocialneurosciencelab.github.io/wellping/login?code=__debug__%20__test__%20https%3A%2F%2Fwellping_local__.ssnl.stanford.edu%2Fdebug.json
 
 This access the local study file "config/survey.json".
 

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -15,7 +15,6 @@ import {
 import { WebView } from "react-native-webview";
 
 import SurveyScreen, { SurveyScreenState } from "./SurveyScreen";
-import { Loading } from "./components/Loading";
 import { AnswerEntity } from "./entities/AnswerEntity";
 import { PingEntity } from "./entities/PingEntity";
 import {
@@ -64,6 +63,7 @@ import {
 import { getAllStreamNames, getStudyInfoAsync } from "./helpers/studyFile";
 import { styles } from "./helpers/styles";
 import { Streams, StreamName, StudyInfo } from "./helpers/types";
+import LoadingScreen from "./screens/LoadingScreen";
 
 interface HomeScreenProps {
   studyInfo: StudyInfo;
@@ -243,7 +243,7 @@ export default class HomeScreen extends React.Component<
     } = this.state;
 
     if (isLoading) {
-      return <Loading />;
+      return <LoadingScreen />;
     }
 
     const ExtraView = allowsNotifications ? (

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Text } from "react-native";
 
 import HomeScreen from "./HomeScreen";
-import { Loading } from "./components/Loading";
 import { clearCurrentStudyFileAsync } from "./helpers/asyncStorage/studyFile";
 import {
   storeTempStudyFileAsync,
@@ -23,6 +22,7 @@ import {
   studyFileExistsAsync,
 } from "./helpers/studyFile";
 import { StudyFile } from "./helpers/types";
+import LoadingScreen from "./screens/LoadingScreen";
 import LoginScreen, {
   ParamDownloadAndParseStudyFileAsync,
 } from "./screens/LoginScreen";
@@ -170,7 +170,7 @@ export default class RootScreen extends React.Component<
   render() {
     const { isLoading, userInfo, studyFileErrorText } = this.state;
     if (isLoading) {
-      return <Loading />;
+      return <LoadingScreen />;
     }
 
     if (studyFileErrorText) {

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -164,7 +164,7 @@ export default class RootScreen extends React.Component<
   async logoutAsync() {
     await clearUserAsync();
     await clearCurrentStudyFileAsync();
-    this.setState({ userInfo: null });
+    this.setState({ userInfo: null, survey: undefined });
   }
 
   render() {

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,14 +1,34 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, Button } from "react-native";
 
-import { JS_VERSION_NUMBER } from "../helpers/debug";
+import { JS_VERSION_NUMBER, shareDebugText } from "../helpers/debug";
 import { styles } from "../helpers/styles";
 
 export const Loading: React.FunctionComponent = () => {
   return (
     <View>
-      <Text style={styles.onlyTextStyle}>Loading...</Text>
-      <Text style={{ textAlign: "center", marginTop: 10, color: "lightgray" }}>
+      <Text style={{ ...styles.onlyTextStyle, fontWeight: "bold" }}>
+        Loading...
+      </Text>
+      <Text
+        style={{
+          textAlign: "center",
+          marginHorizontal: 20,
+          marginTop: 50,
+          color: "lightgray",
+        }}
+      >
+        If you are stuck on this page, please click the button below and contact
+        the research staff.
+      </Text>
+      <Button
+        title="Share Error"
+        color="lightgray"
+        onPress={() => {
+          shareDebugText("Stuck on the loading page.");
+        }}
+      />
+      <Text style={{ textAlign: "center", marginTop: 50, color: "lightgray" }}>
         v.{JS_VERSION_NUMBER}
       </Text>
     </View>

--- a/src/helpers/debug.ts
+++ b/src/helpers/debug.ts
@@ -5,7 +5,7 @@ import { Share, Alert } from "react-native";
 // which is the number submitted App Store and Google Store.
 // This is the JS version number which can be updated OTA.
 // Format: [year - 2019].month.day.[the number of version on that day].
-export const JS_VERSION_NUMBER = "1.8.2.3";
+export const JS_VERSION_NUMBER = "1.8.3.1";
 export const NATIVE_VERSION_NUMBER = Constants.nativeAppVersion;
 export const NATIVE_BUILD_NUMBER = Constants.nativeBuildVersion;
 

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -4,7 +4,7 @@ import { View, Text, Button } from "react-native";
 import { JS_VERSION_NUMBER, shareDebugText } from "../helpers/debug";
 import { styles } from "../helpers/styles";
 
-export const Loading: React.FunctionComponent = () => {
+const LoadingScreen: React.FunctionComponent = () => {
   return (
     <View>
       <Text style={{ ...styles.onlyTextStyle, fontWeight: "bold" }}>
@@ -34,3 +34,5 @@ export const Loading: React.FunctionComponent = () => {
     </View>
   );
 };
+
+export default LoadingScreen;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -173,7 +173,7 @@ export default class LoginScreen extends React.Component<
     } catch (e) {
       this.setState({
         disableLoginButton: false,
-        errorText: `Your login code is invalid:\n${e}`,
+        errorText: `**Your login code is invalid**\n${e}`,
       });
       return;
     }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -24,6 +24,10 @@ import {
 import { LoginSchema } from "../helpers/schemas/Login";
 import { getStudyFileAsync } from "../helpers/studyFile";
 
+// This is an ugly hack so that the init url won't pop up again if the user log
+// in and then immediately log out.
+let firstTimeLoadingLoginScreen = true;
+
 export type ParamDownloadAndParseStudyFileAsync = {
   url: string;
   isRedownload: boolean;
@@ -91,8 +95,13 @@ export default class LoginScreen extends React.Component<
 
   async componentDidMount() {
     // If LoginScreen is loaded, it means that the user haven't logged in yet.
-    // So can addEventListener
-    this.handleUrl(await Linking.parseInitialURLAsync());
+    // So we can parse initial url and addEventListener.
+    if (firstTimeLoadingLoginScreen) {
+      // We have to check this, or else when the user log in and then
+      // immediately log out, they will be presented with this again.
+      this.handleUrl(await Linking.parseInitialURLAsync());
+      firstTimeLoadingLoginScreen = false;
+    }
     Linking.addEventListener("url", this.listenToUrlWhenForegroundHandler);
   }
 

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -41,6 +41,7 @@ interface LoginScreenState {
   unableToParticipate: boolean;
   formData?: string;
   disableLoginButton: boolean;
+  loadingText: string | null;
   errorText: string | null;
 }
 
@@ -54,6 +55,7 @@ export default class LoginScreen extends React.Component<
     this.state = {
       unableToParticipate: false,
       disableLoginButton: false,
+      loadingText: null,
       errorText: null,
     };
   }
@@ -139,7 +141,8 @@ export default class LoginScreen extends React.Component<
     }
 
     this.setState({
-      errorText: "Magical things happening... 🧙‍♂️",
+      errorText: null,
+      loadingText: "Magical things happening...",
     });
 
     let user!: User;
@@ -179,7 +182,7 @@ export default class LoginScreen extends React.Component<
     }
 
     this.setState({
-      errorText: "Loading study data... ☁️",
+      loadingText: "Loading study data...",
     });
 
     if (
@@ -202,7 +205,7 @@ export default class LoginScreen extends React.Component<
     const survey = await getStudyFileAsync();
 
     this.setState({
-      errorText: "Authenticating... 🤖",
+      loadingText: "Authenticating...",
     });
 
     const error = await registerUserAsync(user);
@@ -231,6 +234,7 @@ export default class LoginScreen extends React.Component<
 
               this.setState(
                 {
+                  loadingText: null,
                   errorText: null,
                   disableLoginButton: false,
                 },
@@ -253,7 +257,7 @@ export default class LoginScreen extends React.Component<
   };
 
   render() {
-    const { errorText, unableToParticipate } = this.state;
+    const { loadingText, errorText, unableToParticipate } = this.state;
 
     if (unableToParticipate) {
       return (
@@ -303,7 +307,7 @@ export default class LoginScreen extends React.Component<
           onPress={this.loginAsync}
         />
         {errorText ? (
-          <View style={{ marginTop: 10, marginBottom: 30 }}>
+          <View style={{ marginTop: 10 }}>
             <Text style={{ fontWeight: "bold" }}>{errorText}</Text>
             <Button
               // TODO: MOVE BUTTON BEFORE TEXT SO THAT WHEN THE ERROR MESSAGE IS TOO LONG IT WON'T BE PROBLEM
@@ -314,6 +318,19 @@ export default class LoginScreen extends React.Component<
               color="red"
               title="Share the error message with the research staff"
             />
+          </View>
+        ) : undefined}
+        {loadingText && !errorText ? (
+          <View style={{ marginTop: 10 }}>
+            <Text
+              style={{
+                fontWeight: "bold",
+                textAlign: "center",
+                fontSize: 20,
+              }}
+            >
+              {loadingText}
+            </Text>
           </View>
         ) : undefined}
         <TouchableWithoutFeedback
@@ -330,7 +347,7 @@ export default class LoginScreen extends React.Component<
           <Text
             style={{
               textAlign: "center",
-              marginTop: 10,
+              marginTop: 50,
               color: "lightgray",
             }}
           >

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -128,6 +128,8 @@ export default class LoginScreen extends React.Component<
 
   loginAsync = async () => {
     this.setState({
+      errorText: null,
+      loadingText: null,
       disableLoginButton: true,
     });
 
@@ -141,7 +143,6 @@ export default class LoginScreen extends React.Component<
     }
 
     this.setState({
-      errorText: null,
       loadingText: "Magical things happening...",
     });
 

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -210,6 +210,10 @@ export default class LoginScreen extends React.Component<
 
     const error = await registerUserAsync(user);
     if (!error) {
+      this.setState({
+        loadingText: "Logged in!",
+      });
+
       Alert.alert(
         "Welcome to Well Ping!",
         `Please review the consent form.`,

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -173,10 +173,7 @@ export default class LoginScreen extends React.Component<
     } catch (e) {
       this.setState({
         disableLoginButton: false,
-        errorText:
-          "Your login code is invalid. Please screenshot " +
-          "the current page and contact the research staff.\n\n" +
-          `${e}`,
+        errorText: `Your login code is invalid:\n${e}`,
       });
       return;
     }
@@ -306,21 +303,30 @@ export default class LoginScreen extends React.Component<
           }}
         />
         <Button
-          title="Log in"
+          title="Log In"
           disabled={this.state.disableLoginButton}
           onPress={this.loginAsync}
         />
         {errorText ? (
-          <View style={{ marginTop: 10 }}>
-            <Text style={{ fontWeight: "bold" }}>{errorText}</Text>
+          <View
+            style={{
+              marginVertical: 5,
+              padding: 10,
+              borderColor: "lightcoral",
+              borderWidth: 1,
+            }}
+          >
+            <Text style={{ fontWeight: "bold" }}>
+              {`A problem occurred! Please review the error log below. ` +
+                `If necessary, please press the "Share Error" button at the ` +
+                `bottom and send the error log to the research staff.`}
+            </Text>
+            <Text style={{ marginTop: 20 }}>{errorText}</Text>
             <Button
-              // TODO: MOVE BUTTON BEFORE TEXT SO THAT WHEN THE ERROR MESSAGE IS TOO LONG IT WON'T BE PROBLEM
-              // TODO: ADD A TEXT LIKE "LIKE THE BUTTON ABOVE TO SHARE ERROR WITH RESEARCH STAFF"
               onPress={() => {
                 shareDebugText(errorText);
               }}
-              color="red"
-              title="Share the error message with the research staff"
+              title="Share Error"
             />
           </View>
         ) : undefined}


### PR DESCRIPTION
- Use `username password url` as login code instead of the Base64 encoded JSON in https://github.com/StanfordSocialNeuroscienceLab/WellPing/pull/19.
- Rename `Loading` to `LoadingScreen`.
- Properly support automatically fill in login code from the universal/deep links (extending https://github.com/StanfordSocialNeuroscienceLab/WellPing/pull/22).
- Add a `loadingText` status and use that (instead of `errorText`) for loading texts.
- Improve the UI for login error (`errorText`) and add a button for the user to directly share the error.

Resolves https://github.com/StanfordSocialNeuroscienceLab/WellPing/issues/21.