### PR TITLE
Schemas changes related to `Choices`

### DIFF
--- a/config/survey.json
+++ b/config/survey.json
@@ -25,7 +25,7 @@
       "5": ["myStream", "myStream", "myStream", "myStream"],
       "6": ["myStream", "myStream", "myStream", "myStream"]
     },
-    "streamInCaseOfError": "errorStream",
+    "streamInCaseOfError": "myStream",
     "streamsNotReplacedByFollowupStream": ["myStream"],
     "notificationContent": {
       "default": {

--- a/config/survey.json
+++ b/config/survey.json
@@ -62,16 +62,16 @@
         "type": "ChoicesWithSingleAnswer",
         "question": "Which of the following best categorizes the PRIMARY stress you are experiencing?",
         "choices": [
-          { "key": "academic", "value": "Academic" },
-          { "key": "social", "value": "Social/relationship" },
-          { "key": "mental", "value": "Mental health" },
-          { "key": "physical", "value": "Physical health" },
-          { "key": "financial", "value": "Financial" },
-          { "key": "noStress", "value": "Not experiencing stress" },
-          { "key": "other", "value": "Other" }
+          "Academic",
+          "Social/relationship",
+          "Mental health",
+          "Physical health",
+          "Financial",
+          "Not experiencing stress",
+          "Other"
         ],
         "randomizeChoicesOrder": true,
-        "randomizeExceptForChoiceIds": ["noStress", "other"],
+        "randomizeExceptForChoiceIds": ["Not experiencing stress", "Other"],
         "next": "StressDurationNum"
       },
       "StressDurationNum": {
@@ -85,14 +85,14 @@
         "type": "ChoicesWithMultipleAnswers",
         "question": "Which of the following have you done in response your {PREV:Stressor} stress? Please select all that apply.",
         "choices": [
-          { "key": "think", "value": "I thought extensively about the causes / consequences" },
-          { "key": "noThink", "value": "I tried not to think about it" },
-          { "key": "brightSide", "value": "I thought about the bright side" },
-          { "key": "improve", "value": "I thought about how to improve the situation" },
-          { "key": "other", "value": "Other" }
+          "I thought extensively about the causes / consequences",
+          "I tried not to think about it",
+          "I thought about the bright side",
+          "I thought about how to improve the situation",
+          "Other"
         ],
         "randomizeChoicesOrder": true,
-        "randomizeExceptForChoiceIds": ["other"],
+        "randomizeExceptForChoiceIds": ["Other"],
         "next": "SocInteraction"
       },
       "SocInteraction": {
@@ -122,13 +122,13 @@
         "question": "How would you best describe your relationship to the people you had an interaction with?",
         "placeholder": "Select a category...",
         "choices": [
-          { "key": "friend", "value": "Friend" },
-          { "key": "coworker", "value": "Co-worker" },
-          { "key": "parent", "value": "Parent" },
-          { "key": "relative", "value": "Sibling / other relative" },
-          { "key": "partner", "value": "Significant other" },
-          { "key": "stranger", "value": "Stranger" },
-          { "key": "other", "value": "Other" }
+          "Friend",
+          "Co-worker",
+          "Parent",
+          "Sibling / other relative",
+          "Significant other",
+          "Stranger",
+          "Other"
         ],
         "forceChoice": true,
         "max": 3,

--- a/src/SurveyScreen.tsx
+++ b/src/SurveyScreen.tsx
@@ -142,16 +142,14 @@ export default class SurveyScreen extends React.Component<
               );
             }
 
-            const csaAnswerChoice = csaQuestion.choices.find(
-              (choice) => choice.key === csaAnswer.data?.value,
-            );
-            if (csaAnswerChoice == null) {
+            const csaAnswerChoiceValue = csaAnswer.data?.value;
+            if (csaAnswerChoiceValue == null) {
               return getNonCriticalProblemTextForUser(
-                `csaAnswerChoice (from ${csaQuestion.id}) == null`,
+                `csaAnswerChoiceValue (from ${csaQuestion.id}) == null`,
               );
             }
 
-            return decapitalizeFirstCharacter(csaAnswerChoice.value);
+            return decapitalizeFirstCharacter(csaAnswerChoiceValue);
           }
 
           default:

--- a/src/__tests__/helpers/schemas/Question/ChoicesQuestionSchema.test.ts
+++ b/src/__tests__/helpers/schemas/Question/ChoicesQuestionSchema.test.ts
@@ -11,10 +11,7 @@ describe("ChoicesQuestionSchema", () => {
       id: "Feel_Ideal",
       question: "Choice question",
       next: "Next_Question",
-      choices: [
-        { key: "hello", value: "Hello" },
-        { key: "world", value: "World" },
-      ],
+      choices: ["Hello?", "World!"],
     };
 
     expect(() => {
@@ -64,30 +61,59 @@ describe("ChoicesQuestionSchema", () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
-    test("should be ChoiceSchema objects", () => {
+    test("should be an array of strings", () => {
       expect(() => {
         ChoicesQuestionSchema.parse({
           ...question,
-          choices: [
-            { key: "hello", value: "Hello" },
-            { key: "world", value: "World" },
-          ],
+          choices: ["Hello", "World"],
         });
       }).not.toThrowError();
 
       expect(() => {
         ChoicesQuestionSchema.parse({
           ...question,
-          choices: ["hello", "world"],
+          choices: ["人之初", "性本善"],
         });
-      }).toThrowErrorMatchingSnapshot("strings");
+      }).not.toThrowError();
 
       expect(() => {
         ChoicesQuestionSchema.parse({
           ...question,
           choices: [2, 3, 5],
         });
-      }).toThrowErrorMatchingSnapshot("numbers");
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test("choices string cannot be empty", () => {
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: ["", "world"],
+        });
+      }).toThrowErrorMatchingSnapshot();
+
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: [""],
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test("choices should not be duplicated", () => {
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: ["world", "world"],
+        });
+      }).toThrowErrorMatchingSnapshot();
+
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: ["行路难", "行路难"],
+        });
+      }).toThrowErrorMatchingSnapshot();
     });
   });
 
@@ -96,10 +122,7 @@ describe("ChoicesQuestionSchema", () => {
       id: "Feel_Ideal",
       type: QuestionType.ChoicesWithSingleAnswer,
       question: "Choice question",
-      choices: [
-        { key: "hello", value: "Hello" },
-        { key: "world", value: "World" },
-      ],
+      choices: ["Hello?", "World!"],
       next: "Next_Question",
     };
 
@@ -145,7 +168,7 @@ describe("ChoicesQuestionSchema", () => {
         ChoicesQuestionSchema.parse({
           ...question,
           specialCasesStartId: {
-            hello: "hello_world",
+            "Hello?": "hello_world",
           },
         });
       }).not.toThrowError();
@@ -156,7 +179,7 @@ describe("ChoicesQuestionSchema", () => {
         ChoicesQuestionSchema.parse({
           ...question,
           specialCasesStartId: {
-            hello: "hello_world",
+            "Hello?": "hello_world",
             _pna: "goodbye",
           },
         });
@@ -178,7 +201,7 @@ describe("ChoicesQuestionSchema", () => {
           ...question,
           specialCasesStartId: {
             notakey: "nonono",
-            world: "stillno",
+            "World!": "stillno",
           },
         });
       }).toThrowErrorMatchingSnapshot("non-choices key with choice key");
@@ -199,7 +222,7 @@ describe("ChoicesQuestionSchema", () => {
         ChoicesQuestionSchema.parse({
           ...question,
           specialCasesStartId: {
-            hello: "new_world",
+            "Hello?": "new_world",
             _pna: null,
           },
         });
@@ -209,7 +232,7 @@ describe("ChoicesQuestionSchema", () => {
         ChoicesQuestionSchema.parse({
           ...question,
           specialCasesStartId: {
-            world: null,
+            "World!": null,
           },
         });
       }).not.toThrowError();
@@ -230,10 +253,7 @@ describe("ChoicesQuestionSchema", () => {
       id: "Feel_Ideal",
       type: QuestionType.ChoicesWithSingleAnswer,
       question: "Choice question",
-      choices: [
-        { key: "hello", value: "Hello" },
-        { key: "world", value: "World" },
-      ],
+      choices: ["Hello?", "World!"],
       next: "Next_Question",
     };
 
@@ -276,10 +296,7 @@ describe("ChoicesQuestionSchema", () => {
       id: "Feel_Ideal",
       type: QuestionType.ChoicesWithSingleAnswer,
       question: "Choice question",
-      choices: [
-        { key: "hello", value: "Hello" },
-        { key: "world", value: "World" },
-      ],
+      choices: ["Hello?", "World!"],
       randomizeChoicesOrder: true,
       next: "Next_Question",
     };
@@ -306,7 +323,7 @@ describe("ChoicesQuestionSchema", () => {
         ChoicesQuestionSchema.parse({
           ...question,
           randomizeChoicesOrder: false,
-          randomizeExceptForChoiceIds: ["hello"],
+          randomizeExceptForChoiceIds: ["Hello?"],
         });
       }).toThrowErrorMatchingSnapshot();
     });
@@ -324,14 +341,14 @@ describe("ChoicesQuestionSchema", () => {
       expect(() => {
         ChoicesQuestionSchema.parse({
           ...question,
-          randomizeExceptForChoiceIds: ["hello", "world"],
+          randomizeExceptForChoiceIds: ["Hello?", "World!"],
         });
       }).not.toThrowError();
 
       expect(() => {
         ChoicesQuestionSchema.parse({
           ...question,
-          randomizeExceptForChoiceIds: ["world"],
+          randomizeExceptForChoiceIds: ["World!"],
         });
       }).not.toThrowError();
     });
@@ -340,7 +357,7 @@ describe("ChoicesQuestionSchema", () => {
       expect(() => {
         ChoicesQuestionSchema.parse({
           ...question,
-          randomizeExceptForChoiceIds: ["nono", "world"],
+          randomizeExceptForChoiceIds: ["nono", "World!"],
         });
       }).toThrowErrorMatchingSnapshot("with choice keys");
 
@@ -360,10 +377,7 @@ describe("ChoicesWithSingleAnswerQuestionSchema", () => {
       id: "Feel_Ideal",
       question: "Choice question",
       next: "Next_Question",
-      choices: [
-        { key: "hello", value: "Hello" },
-        { key: "world", value: "World" },
-      ],
+      choices: ["Hello?", "World!"],
     };
 
     expect(() => {
@@ -395,10 +409,7 @@ describe("ChoicesWithMultipleAnswersQuestionSchema", () => {
       id: "Feel_Ideal",
       question: "Choice question",
       next: "Next_Question",
-      choices: [
-        { key: "hello", value: "Hello" },
-        { key: "world", value: "World" },
-      ],
+      choices: ["Hello?", "World!"],
     };
 
     expect(() => {

--- a/src/__tests__/helpers/schemas/Question/MultipleTextQuestionSchema.test.ts
+++ b/src/__tests__/helpers/schemas/Question/MultipleTextQuestionSchema.test.ts
@@ -284,11 +284,57 @@ describe("MultipleTextQuestionSchema", () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
-    test("should not be an array of string", () => {
+    test("should be an array of strings", () => {
       expect(() => {
         MultipleTextQuestionSchema.parse({
           ...question,
           choices: ["hello", "world"],
+        });
+      }).not.toThrowError();
+
+      expect(() => {
+        MultipleTextQuestionSchema.parse({
+          ...question,
+          choices: ["Hello world!"],
+        });
+      }).not.toThrowError();
+
+      expect(() => {
+        MultipleTextQuestionSchema.parse({
+          ...question,
+          choices: ["黄河远上白云间", "昔人已乘黄鹤去"],
+        });
+      }).not.toThrowError();
+    });
+
+    test("choices string cannot be empty", () => {
+      expect(() => {
+        MultipleTextQuestionSchema.parse({
+          ...question,
+          choices: ["", "world"],
+        });
+      }).toThrowErrorMatchingSnapshot();
+
+      expect(() => {
+        MultipleTextQuestionSchema.parse({
+          ...question,
+          choices: [""],
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test("choices should not be duplicated", () => {
+      expect(() => {
+        MultipleTextQuestionSchema.parse({
+          ...question,
+          choices: ["world", "world"],
+        });
+      }).toThrowErrorMatchingSnapshot();
+
+      expect(() => {
+        MultipleTextQuestionSchema.parse({
+          ...question,
+          choices: ["行路难", "行路难"],
         });
       }).toThrowErrorMatchingSnapshot();
     });
@@ -316,40 +362,6 @@ describe("MultipleTextQuestionSchema", () => {
         });
       }).toThrowErrorMatchingSnapshot("url");
     });
-
-    test("can be any Choice array", () => {
-      expect(() => {
-        MultipleTextQuestionSchema.parse({
-          ...question,
-          choices: [
-            {
-              key: "hello",
-              value: "HELLO WORLD!",
-            },
-          ],
-        });
-      }).not.toThrowError();
-
-      expect(() => {
-        MultipleTextQuestionSchema.parse({
-          ...question,
-          choices: [
-            {
-              key: "hello",
-              value: "HELLO!",
-            },
-            {
-              key: "arefly",
-              value: "arefly.com!",
-            },
-            {
-              key: "world",
-              value: "WORLD!",
-            },
-          ],
-        });
-      }).not.toThrowError();
-    });
   });
 
   describe("forceChoice", () => {
@@ -360,20 +372,7 @@ describe("MultipleTextQuestionSchema", () => {
       variableName: "TARGET_NAME",
       indexName: "INDEX",
       max: 3,
-      choices: [
-        {
-          key: "hello",
-          value: "HELLO!",
-        },
-        {
-          key: "arefly",
-          value: "arefly.com!",
-        },
-        {
-          key: "world",
-          value: "WORLD!",
-        },
-      ],
+      choices: ["HELLO!", "arefly.com!", "WORLD!"],
       next: "Next_Question",
     };
 

--- a/src/__tests__/helpers/schemas/Question/__snapshots__/ChoicesQuestionSchema.test.ts.snap
+++ b/src/__tests__/helpers/schemas/Question/__snapshots__/ChoicesQuestionSchema.test.ts.snap
@@ -1,27 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ChoicesQuestionSchema choices should be ChoiceSchema objects: numbers 1`] = `
-"3 validation issue(s)
+exports[`ChoicesQuestionSchema choices choices should not be duplicated 1`] = `
+"1 validation issue(s)
 
-  Issue #0: invalid_type at choices.0
-  Expected object, received number
-
-  Issue #1: invalid_type at choices.1
-  Expected object, received number
-
-  Issue #2: invalid_type at choices.2
-  Expected object, received number
+  Issue #0: custom_error at choices
+  There should not be duplicate elements in the choices list.
 "
 `;
 
-exports[`ChoicesQuestionSchema choices should be ChoiceSchema objects: strings 1`] = `
-"2 validation issue(s)
+exports[`ChoicesQuestionSchema choices choices should not be duplicated 2`] = `
+"1 validation issue(s)
+
+  Issue #0: custom_error at choices
+  There should not be duplicate elements in the choices list.
+"
+`;
+
+exports[`ChoicesQuestionSchema choices choices string cannot be empty 1`] = `
+"1 validation issue(s)
+
+  Issue #0: too_small at choices.0
+  Should be at least 1 characters
+"
+`;
+
+exports[`ChoicesQuestionSchema choices choices string cannot be empty 2`] = `
+"1 validation issue(s)
+
+  Issue #0: too_small at choices.0
+  Should be at least 1 characters
+"
+`;
+
+exports[`ChoicesQuestionSchema choices should be an array of strings 1`] = `
+"3 validation issue(s)
 
   Issue #0: invalid_type at choices.0
-  Expected object, received string
+  Expected string, received number
 
   Issue #1: invalid_type at choices.1
-  Expected object, received string
+  Expected string, received number
+
+  Issue #2: invalid_type at choices.2
+  Expected string, received number
 "
 `;
 

--- a/src/__tests__/helpers/schemas/Question/__snapshots__/MultipleTextQuestionSchema.test.ts.snap
+++ b/src/__tests__/helpers/schemas/Question/__snapshots__/MultipleTextQuestionSchema.test.ts.snap
@@ -16,11 +16,35 @@ exports[`MultipleTextQuestionSchema choices TODO: should not be string other tha
 "
 `;
 
-exports[`MultipleTextQuestionSchema choices should not be an array of string 1`] = `
+exports[`MultipleTextQuestionSchema choices choices should not be duplicated 1`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_literal_value at choices
-  Input must be \\"NAMES\\"
+  Issue #0: invalid_union at choices
+  Invalid input
+"
+`;
+
+exports[`MultipleTextQuestionSchema choices choices should not be duplicated 2`] = `
+"1 validation issue(s)
+
+  Issue #0: invalid_union at choices
+  Invalid input
+"
+`;
+
+exports[`MultipleTextQuestionSchema choices choices string cannot be empty 1`] = `
+"1 validation issue(s)
+
+  Issue #0: invalid_union at choices
+  Invalid input
+"
+`;
+
+exports[`MultipleTextQuestionSchema choices choices string cannot be empty 2`] = `
+"1 validation issue(s)
+
+  Issue #0: invalid_union at choices
+  Invalid input
 "
 `;
 

--- a/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
+++ b/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
@@ -75,10 +75,7 @@ const basicTestForChoicesQuestionScreenAsync = async (
 ) => {
   let choices: Choice[];
   if (question.type === QuestionType.YesNo) {
-    choices = [
-      { key: "yes", value: "Yes" },
-      { key: "no", value: "No" },
-    ];
+    choices = ["Yes", "No"];
   } else {
     choices = question.choices;
   }
@@ -119,13 +116,13 @@ const basicTestForChoicesQuestionScreenAsync = async (
   );
   if (question.type !== QuestionType.YesNo) {
     if (question.randomizeChoicesOrder) {
-      expect(displayedList).not.toStrictEqual(FLATTENED_CHOICES_VALUES);
+      expect(displayedList).not.toStrictEqual(CHOICES);
       if (question.randomizeExceptForChoiceIds) {
         // Sort the `randomizeExceptForChoiceIds` by the order of `choices`.
         const sortedRandomizeExceptForChoiceIds = [];
         for (const choice of choices) {
-          if (question.randomizeExceptForChoiceIds.includes(choice.key)) {
-            sortedRandomizeExceptForChoiceIds.push(choice.key);
+          if (question.randomizeExceptForChoiceIds.includes(choice)) {
+            sortedRandomizeExceptForChoiceIds.push(choice);
           }
         }
         // Just a sanity check to make sure the items are the same.
@@ -134,17 +131,15 @@ const basicTestForChoicesQuestionScreenAsync = async (
         );
 
         for (let i = sortedRandomizeExceptForChoiceIds.length; i > 0; i--) {
-          const key =
+          const value =
             sortedRandomizeExceptForChoiceIds[
               sortedRandomizeExceptForChoiceIds.length - i
             ];
-          const value = question.choices.find((choice) => choice.key === key)
-            ?.value;
           expect(displayedList[displayedList.length - i]).toBe(value);
         }
       }
     } else {
-      expect(displayedList).toStrictEqual(FLATTENED_CHOICES_VALUES);
+      expect(displayedList).toStrictEqual(CHOICES);
     }
   }
 
@@ -169,9 +164,7 @@ const inputTestForChoicesWithSingleAnswerQuestionAsync = async (
     const selection = getSelection(inputValue, getAllByA11yLabel);
     fireEvent.press(selection);
 
-    expectedResults = question.choices.find(
-      (choice) => choice.value === inputValue,
-    )?.key!;
+    expectedResults = inputValue;
 
     calledTimes += 1;
     expect(mockOnDataChangeFn).toHaveBeenNthCalledWith(calledTimes, {
@@ -196,7 +189,7 @@ const inputTestForChoicesWithMultipleAnswersQuestionAsync = async (
   const { getAllByA11yLabel } = renderResults;
 
   const expectedResults = question.choices.reduce((map, choice) => {
-    map[choice.key] = false;
+    map[choice] = false;
     return map;
   }, {} as { [key: string]: boolean });
 
@@ -206,8 +199,7 @@ const inputTestForChoicesWithMultipleAnswersQuestionAsync = async (
     const selection = getSelection(inputValue, getAllByA11yLabel);
     fireEvent.press(selection);
 
-    const key = question.choices.find((choice) => choice.value === inputValue)
-      ?.key!;
+    const key = inputValue;
     expectedResults[key] = !expectedResults[key];
 
     calledTimes += 1;
@@ -223,28 +215,27 @@ const inputTestForChoicesWithMultipleAnswersQuestionAsync = async (
 };
 
 const CHOICES = [
-  { key: "wolf", value: "Wolf" },
-  { key: "fox", value: "Fox" },
-  { key: "coyote", value: "Coyote" },
-  { key: "lynx", value: "Lynx" },
-  { key: "panda", value: "Panda" },
-  { key: "other", value: "Other" },
-  { key: "idk", value: "I don't know" },
+  "Wolf",
+  "Fox",
+  "Coyote",
+  "Lynx",
+  "Panda",
+  "Other",
+  "I don't know",
 ];
-const FLATTENED_CHOICES_VALUES = CHOICES.map((choice) => choice.value);
 const CHOICES_TEST_TABLE = [
   [["Wolf", "Coyote"], false, undefined],
-  [["Lynx", "Panda", "Other"], true, ["other"]],
-  [["Fox"], true, ["other", "idk"]],
+  [["Lynx", "Panda", "Other"], true, ["Other"]],
+  [["Fox"], true, ["Other", "I don't know"]],
   [
     ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"],
     true,
-    ["wolf", "fox", "other", "idk"],
+    ["Wolf", "Fox", "Other", "I don't know"],
   ],
   [
     ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"],
     true,
-    ["idk", "other"], // The order should follow `choices`, not here.
+    ["I don't know", "Other"], // The order should follow `choices`, not here.
   ],
   [
     [

--- a/src/__tests__/questionScreens/MultipleTextQuestionScreen.test.tsx
+++ b/src/__tests__/questionScreens/MultipleTextQuestionScreen.test.tsx
@@ -104,8 +104,7 @@ const basicTestForQuestionAsync = async (
       if (typeof question.choices === "string") {
         // TODO: DO THIS
       } else {
-        isInputInChoice =
-          question.choices?.some((e) => e.value === inputValue) || false;
+        isInputInChoice = question.choices?.includes(inputValue) || false;
       }
 
       if (!isInputInChoice) {
@@ -263,13 +262,13 @@ test.each([
 );
 
 const CHOICES = [
-  { key: "friend", value: "Friend" },
-  { key: "coworker", value: "Co-worker" },
-  { key: "parent", value: "Parent" },
-  { key: "relative", value: "Sibling / other relative" },
-  { key: "partner", value: "Significant other" },
-  { key: "stranger", value: "Stranger" },
-  { key: "other", value: "Other" },
+  "Friend",
+  "Co-worker",
+  "Parent",
+  "Sibling / other relative",
+  "Significant other",
+  "Stranger",
+  "Other",
 ];
 test.each([
   [generateTypingInput(2), 2, true, "Enter a relation..."],

--- a/src/__tests__/questionScreens/MultipleTextQuestionScreen.test.tsx
+++ b/src/__tests__/questionScreens/MultipleTextQuestionScreen.test.tsx
@@ -54,8 +54,9 @@ const basicTestForQuestionAsync = async (
   );
   const { getAllByA11yLabel, getAllByA11yHint } = renderResults;
 
-  // Because there isn't a need to pipe in any data.
-  expect(mockPipeInExtraMetaData).not.toHaveBeenCalled();
+  expect(mockPipeInExtraMetaData).toHaveBeenCalledTimes(
+    question.choices?.length || 0,
+  ); // For each choices
 
   expect(mockSetDataValidationFunction).toHaveBeenCalledTimes(1);
   expect(typeof codeDataValidationFunction).toBe("function");

--- a/src/__tests__/questionScreens/__snapshots__/ChoicesQuestionScreen.test.tsx.snap
+++ b/src/__tests__/questionScreens/__snapshots__/ChoicesQuestionScreen.test.tsx.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["idk", "other"]): data 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["I don't know", "Other"]): data 1`] = `
 Object {
-  "coyote": true,
-  "fox": false,
-  "idk": false,
-  "lynx": false,
-  "other": false,
-  "panda": false,
-  "wolf": false,
+  "Coyote": true,
+  "Fox": false,
+  "I don't know": false,
+  "Lynx": false,
+  "Other": false,
+  "Panda": false,
+  "Wolf": false,
 }
 `;
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["idk", "other"]): displayed list 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["I don't know", "Other"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Coyote",
@@ -24,19 +24,19 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["wolf", "fox", "other", "idk"]): data 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["Wolf", "Fox", "Other", "I don't know"]): data 1`] = `
 Object {
-  "coyote": false,
-  "fox": true,
-  "idk": true,
-  "lynx": true,
-  "other": false,
-  "panda": false,
-  "wolf": true,
+  "Coyote": false,
+  "Fox": true,
+  "I don't know": true,
+  "Lynx": true,
+  "Other": false,
+  "Panda": false,
+  "Wolf": true,
 }
 `;
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["wolf", "fox", "other", "idk"]): displayed list 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["Wolf", "Fox", "Other", "I don't know"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Panda",
@@ -50,13 +50,13 @@ Array [
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "I don't know"] (randomize order true except for undefined): data 1`] = `
 Object {
-  "coyote": false,
-  "fox": false,
-  "idk": true,
-  "lynx": false,
-  "other": false,
-  "panda": false,
-  "wolf": false,
+  "Coyote": false,
+  "Fox": false,
+  "I don't know": true,
+  "Lynx": false,
+  "Other": false,
+  "Panda": false,
+  "Wolf": false,
 }
 `;
 
@@ -72,19 +72,19 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Fox"] (randomize order true except for ["other", "idk"]): data 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Fox"] (randomize order true except for ["Other", "I don't know"]): data 1`] = `
 Object {
-  "coyote": false,
-  "fox": true,
-  "idk": false,
-  "lynx": false,
-  "other": false,
-  "panda": false,
-  "wolf": false,
+  "Coyote": false,
+  "Fox": true,
+  "I don't know": false,
+  "Lynx": false,
+  "Other": false,
+  "Panda": false,
+  "Wolf": false,
 }
 `;
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Fox"] (randomize order true except for ["other", "idk"]): displayed list 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Fox"] (randomize order true except for ["Other", "I don't know"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Coyote",
@@ -96,19 +96,19 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["other"]): data 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["Other"]): data 1`] = `
 Object {
-  "coyote": false,
-  "fox": false,
-  "idk": false,
-  "lynx": true,
-  "other": true,
-  "panda": true,
-  "wolf": false,
+  "Coyote": false,
+  "Fox": false,
+  "I don't know": false,
+  "Lynx": true,
+  "Other": true,
+  "Panda": true,
+  "Wolf": false,
 }
 `;
 
-exports[`ChoicesWithMultipleAnswers question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["other"]): displayed list 1`] = `
+exports[`ChoicesWithMultipleAnswers question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["Other"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Coyote",
@@ -122,13 +122,13 @@ Array [
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Wolf", "Coyote"] (randomize order false except for undefined): data 1`] = `
 Object {
-  "coyote": true,
-  "fox": false,
-  "idk": false,
-  "lynx": false,
-  "other": false,
-  "panda": false,
-  "wolf": true,
+  "Coyote": true,
+  "Fox": false,
+  "I don't know": false,
+  "Lynx": false,
+  "Other": false,
+  "Panda": false,
+  "Wolf": true,
 }
 `;
 
@@ -146,13 +146,13 @@ Array [
 
 exports[`ChoicesWithMultipleAnswers question with input sequence [] (randomize order false except for undefined): data 1`] = `
 Object {
-  "coyote": false,
-  "fox": false,
-  "idk": false,
-  "lynx": false,
-  "other": false,
-  "panda": false,
-  "wolf": false,
+  "Coyote": false,
+  "Fox": false,
+  "I don't know": false,
+  "Lynx": false,
+  "Other": false,
+  "Panda": false,
+  "Wolf": false,
 }
 `;
 
@@ -168,9 +168,9 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["idk", "other"]): data 1`] = `"coyote"`;
+exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["I don't know", "Other"]): data 1`] = `"Coyote"`;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["idk", "other"]): displayed list 1`] = `
+exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["I don't know", "Other"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Coyote",
@@ -182,9 +182,9 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["wolf", "fox", "other", "idk"]): data 1`] = `"idk"`;
+exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["Wolf", "Fox", "Other", "I don't know"]): data 1`] = `"I don't know"`;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["wolf", "fox", "other", "idk"]): displayed list 1`] = `
+exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["Wolf", "Fox", "Other", "I don't know"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Panda",
@@ -196,7 +196,7 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "I don't know"] (randomize order true except for undefined): data 1`] = `"idk"`;
+exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "I don't know"] (randomize order true except for undefined): data 1`] = `"I don't know"`;
 
 exports[`ChoicesWithSingleAnswer question with input sequence ["Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "I don't know"] (randomize order true except for undefined): displayed list 1`] = `
 Array [
@@ -210,9 +210,9 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Fox"] (randomize order true except for ["other", "idk"]): data 1`] = `"fox"`;
+exports[`ChoicesWithSingleAnswer question with input sequence ["Fox"] (randomize order true except for ["Other", "I don't know"]): data 1`] = `"Fox"`;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Fox"] (randomize order true except for ["other", "idk"]): displayed list 1`] = `
+exports[`ChoicesWithSingleAnswer question with input sequence ["Fox"] (randomize order true except for ["Other", "I don't know"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Coyote",
@@ -224,9 +224,9 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["other"]): data 1`] = `"other"`;
+exports[`ChoicesWithSingleAnswer question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["Other"]): data 1`] = `"Other"`;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["other"]): displayed list 1`] = `
+exports[`ChoicesWithSingleAnswer question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["Other"]): displayed list 1`] = `
 Array [
   "Lynx",
   "Coyote",
@@ -238,7 +238,7 @@ Array [
 ]
 `;
 
-exports[`ChoicesWithSingleAnswer question with input sequence ["Wolf", "Coyote"] (randomize order false except for undefined): data 1`] = `"coyote"`;
+exports[`ChoicesWithSingleAnswer question with input sequence ["Wolf", "Coyote"] (randomize order false except for undefined): data 1`] = `"Coyote"`;
 
 exports[`ChoicesWithSingleAnswer question with input sequence ["Wolf", "Coyote"] (randomize order false except for undefined): displayed list 1`] = `
 Array [

--- a/src/__tests__/questionScreens/__snapshots__/ChoicesQuestionScreen.test.tsx.snap
+++ b/src/__tests__/questionScreens/__snapshots__/ChoicesQuestionScreen.test.tsx.snap
@@ -1,15 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["I don't know", "Other"]): data 1`] = `
-Object {
-  "Coyote": true,
-  "Fox": false,
-  "I don't know": false,
-  "Lynx": false,
-  "Other": false,
-  "Panda": false,
-  "Wolf": false,
-}
+Array [
+  Array [
+    "Lynx",
+    false,
+  ],
+  Array [
+    "Coyote",
+    true,
+  ],
+  Array [
+    "Wolf",
+    false,
+  ],
+  Array [
+    "Panda",
+    false,
+  ],
+  Array [
+    "Fox",
+    false,
+  ],
+  Array [
+    "Other",
+    false,
+  ],
+  Array [
+    "I don't know",
+    false,
+  ],
+]
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["I don't know", "Other"]): displayed list 1`] = `
@@ -25,15 +46,36 @@ Array [
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["Wolf", "Fox", "Other", "I don't know"]): data 1`] = `
-Object {
-  "Coyote": false,
-  "Fox": true,
-  "I don't know": true,
-  "Lynx": true,
-  "Other": false,
-  "Panda": false,
-  "Wolf": true,
-}
+Array [
+  Array [
+    "Lynx",
+    true,
+  ],
+  Array [
+    "Panda",
+    false,
+  ],
+  Array [
+    "Coyote",
+    false,
+  ],
+  Array [
+    "Wolf",
+    true,
+  ],
+  Array [
+    "Fox",
+    true,
+  ],
+  Array [
+    "Other",
+    false,
+  ],
+  Array [
+    "I don't know",
+    true,
+  ],
+]
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Lynx", "Wolf", "Fox", "Coyote", "I don't know"] (randomize order true except for ["Wolf", "Fox", "Other", "I don't know"]): displayed list 1`] = `
@@ -49,15 +91,36 @@ Array [
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "I don't know"] (randomize order true except for undefined): data 1`] = `
-Object {
-  "Coyote": false,
-  "Fox": false,
-  "I don't know": true,
-  "Lynx": false,
-  "Other": false,
-  "Panda": false,
-  "Wolf": false,
-}
+Array [
+  Array [
+    "Lynx",
+    false,
+  ],
+  Array [
+    "I don't know",
+    true,
+  ],
+  Array [
+    "Wolf",
+    false,
+  ],
+  Array [
+    "Panda",
+    false,
+  ],
+  Array [
+    "Other",
+    false,
+  ],
+  Array [
+    "Fox",
+    false,
+  ],
+  Array [
+    "Coyote",
+    false,
+  ],
+]
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "Coyote", "Wolf", "Fox", "Lynx", "Panda", "Other", "I don't know"] (randomize order true except for undefined): displayed list 1`] = `
@@ -73,15 +136,36 @@ Array [
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Fox"] (randomize order true except for ["Other", "I don't know"]): data 1`] = `
-Object {
-  "Coyote": false,
-  "Fox": true,
-  "I don't know": false,
-  "Lynx": false,
-  "Other": false,
-  "Panda": false,
-  "Wolf": false,
-}
+Array [
+  Array [
+    "Lynx",
+    false,
+  ],
+  Array [
+    "Coyote",
+    false,
+  ],
+  Array [
+    "Wolf",
+    false,
+  ],
+  Array [
+    "Panda",
+    false,
+  ],
+  Array [
+    "Fox",
+    true,
+  ],
+  Array [
+    "Other",
+    false,
+  ],
+  Array [
+    "I don't know",
+    false,
+  ],
+]
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Fox"] (randomize order true except for ["Other", "I don't know"]): displayed list 1`] = `
@@ -97,15 +181,36 @@ Array [
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["Other"]): data 1`] = `
-Object {
-  "Coyote": false,
-  "Fox": false,
-  "I don't know": false,
-  "Lynx": true,
-  "Other": true,
-  "Panda": true,
-  "Wolf": false,
-}
+Array [
+  Array [
+    "Lynx",
+    true,
+  ],
+  Array [
+    "Coyote",
+    false,
+  ],
+  Array [
+    "Wolf",
+    false,
+  ],
+  Array [
+    "Panda",
+    true,
+  ],
+  Array [
+    "I don't know",
+    false,
+  ],
+  Array [
+    "Fox",
+    false,
+  ],
+  Array [
+    "Other",
+    true,
+  ],
+]
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Lynx", "Panda", "Other"] (randomize order true except for ["Other"]): displayed list 1`] = `
@@ -121,15 +226,36 @@ Array [
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Wolf", "Coyote"] (randomize order false except for undefined): data 1`] = `
-Object {
-  "Coyote": true,
-  "Fox": false,
-  "I don't know": false,
-  "Lynx": false,
-  "Other": false,
-  "Panda": false,
-  "Wolf": true,
-}
+Array [
+  Array [
+    "Wolf",
+    true,
+  ],
+  Array [
+    "Fox",
+    false,
+  ],
+  Array [
+    "Coyote",
+    true,
+  ],
+  Array [
+    "Lynx",
+    false,
+  ],
+  Array [
+    "Panda",
+    false,
+  ],
+  Array [
+    "Other",
+    false,
+  ],
+  Array [
+    "I don't know",
+    false,
+  ],
+]
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Wolf", "Coyote"] (randomize order false except for undefined): displayed list 1`] = `
@@ -145,15 +271,36 @@ Array [
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence [] (randomize order false except for undefined): data 1`] = `
-Object {
-  "Coyote": false,
-  "Fox": false,
-  "I don't know": false,
-  "Lynx": false,
-  "Other": false,
-  "Panda": false,
-  "Wolf": false,
-}
+Array [
+  Array [
+    "Wolf",
+    false,
+  ],
+  Array [
+    "Fox",
+    false,
+  ],
+  Array [
+    "Coyote",
+    false,
+  ],
+  Array [
+    "Lynx",
+    false,
+  ],
+  Array [
+    "Panda",
+    false,
+  ],
+  Array [
+    "Other",
+    false,
+  ],
+  Array [
+    "I don't know",
+    false,
+  ],
+]
 `;
 
 exports[`ChoicesWithMultipleAnswers question with input sequence [] (randomize order false except for undefined): displayed list 1`] = `

--- a/src/helpers/answerTypes.ts
+++ b/src/helpers/answerTypes.ts
@@ -13,10 +13,11 @@ export type ChoicesWithSingleAnswerAnswerData = {
   value: Choice;
 };
 
-// TODO: use [Choice, boolean][] so that the order shown on the screen is kept in the results.
-export type ChoicesWithMultipleAnswersAnswerChoices = {
-  [key: string /* actually Choice */]: boolean;
-};
+// We use an array of tuples here (instead of `{ [key: string]: boolean }`)
+// because the order shown on the screen can be kept in the results.
+// This is potentially helpful for analysis later if the order is randomized
+// as now we know the order the user saw the choices in.
+export type ChoicesWithMultipleAnswersAnswerChoices = [Choice, boolean][];
 export type ChoicesWithMultipleAnswersAnswerData = {
   value: ChoicesWithMultipleAnswersAnswerChoices;
 };

--- a/src/helpers/answerTypes.ts
+++ b/src/helpers/answerTypes.ts
@@ -1,5 +1,5 @@
 import { AnswerEntity } from "../entities/AnswerEntity";
-import { Question, QuestionsList } from "./types";
+import { Question, QuestionsList, Choice } from "./types";
 
 // We use `{ value: ... }` because it seems that `"simple-json"`
 // does not support simply mixing normal values.
@@ -10,11 +10,12 @@ export type SliderAnswerData = {
 };
 
 export type ChoicesWithSingleAnswerAnswerData = {
-  value: string;
+  value: Choice;
 };
 
+// TODO: use [Choice, boolean][] so that the order shown on the screen is kept in the results.
 export type ChoicesWithMultipleAnswersAnswerChoices = {
-  [key: string]: boolean;
+  [key: string /* actually Choice */]: boolean;
 };
 export type ChoicesWithMultipleAnswersAnswerData = {
   value: ChoicesWithMultipleAnswersAnswerChoices;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -14,6 +14,7 @@ import {
   BranchQuestionSchema,
   BranchWithRelativeComparisonQuestionSchema,
   QuestionTypeSchema,
+  ChoicesListSchema,
 } from "./schemas/Question";
 import { StreamsSchema } from "./schemas/Stream";
 import { StudyFileSchema, StudyInfoSchema } from "./schemas/StudyFile";
@@ -22,6 +23,9 @@ import {
   StreamNameSchema,
   StudyIdSchema,
 } from "./schemas/common";
+
+export type Choice = z.infer<typeof ChoiceSchema>;
+export type ChoicesList = z.infer<typeof ChoicesListSchema>;
 
 export type StreamName = z.infer<typeof StreamNameSchema>;
 
@@ -33,7 +37,6 @@ export type Question = z.infer<typeof QuestionSchema>;
 
 export type SliderQuestion = z.infer<typeof SliderQuestionSchema>;
 
-export type Choice = z.infer<typeof ChoiceSchema>;
 export type ChoicesQuestion = z.infer<typeof ChoicesQuestionSchema>;
 
 export type ChoicesWithSingleAnswerQuestion = z.infer<

--- a/src/questionScreens/HowLongAgoQuestion.tsx
+++ b/src/questionScreens/HowLongAgoQuestion.tsx
@@ -1,13 +1,11 @@
 import React from "react";
-import { View, Text, TouchableOpacity, FlatList } from "react-native";
+import { View, FlatList } from "react-native";
 
 import {
   QuestionScreenProps,
-  ChoicesWithMultipleAnswersAnswerChoices,
   HowLongAgoAnswerData,
   HowLongAgoAnswerDataType,
 } from "../helpers/answerTypes";
-import { QuestionType } from "../helpers/helpers";
 import { HowLongAgoQuestion } from "../helpers/types";
 import { ChoiceItem } from "./ChoicesQuestionScreen";
 
@@ -63,8 +61,11 @@ const HowLongAgoQuestionScreen: React.ElementType<HowLongAgoQuestionScreenProps>
             id={item.id}
             title={item.title}
             selected={item.id === `${data[0]}`}
-            onSelect={(id) => {
-              const newData: HowLongAgoAnswerDataType = [Number(id), data[1]];
+            onSelect={() => {
+              const newData: HowLongAgoAnswerDataType = [
+                Number(item.id),
+                data[1],
+              ];
               setData(newData);
               onDataChange({ value: newData } as HowLongAgoAnswerData);
             }}
@@ -81,8 +82,8 @@ const HowLongAgoQuestionScreen: React.ElementType<HowLongAgoQuestionScreenProps>
             id={item.id}
             title={item.title}
             selected={item.id === data[1]}
-            onSelect={(id) => {
-              const newData: HowLongAgoAnswerDataType = [data[0], id];
+            onSelect={() => {
+              const newData: HowLongAgoAnswerDataType = [data[0], item.id];
               setData(newData);
               onDataChange({ value: newData } as HowLongAgoAnswerData);
             }}

--- a/src/questionScreens/MultipleTextQuestionScreen.tsx
+++ b/src/questionScreens/MultipleTextQuestionScreen.tsx
@@ -76,8 +76,8 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
     textFieldsDropdownItems = prestoredChoicesListItems;
   } else if (question.choices) {
     textFieldsDropdownItems = question.choices.map((choice) => ({
-      id: choice.key,
-      name: choice.value,
+      id: choice,
+      name: choice,
     }));
   }
   const textFieldsDropdownNames = textFieldsDropdownItems.map(

--- a/src/questionScreens/MultipleTextQuestionScreen.tsx
+++ b/src/questionScreens/MultipleTextQuestionScreen.tsx
@@ -20,6 +20,7 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
   question,
   onDataChange,
   allAnswers,
+  pipeInExtraMetaData,
   setDataValidationFunction,
 }) => {
   let numberOfTextFields = question.max;
@@ -77,7 +78,7 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
   } else if (question.choices) {
     textFieldsDropdownItems = question.choices.map((choice) => ({
       id: choice,
-      name: choice,
+      name: pipeInExtraMetaData(choice),
     }));
   }
   const textFieldsDropdownNames = textFieldsDropdownItems.map(


### PR DESCRIPTION
- Use `string`s instead of `{ key: string; value: string; }`s for `Choice`.
-  Use `[Choice, boolean][]` for `ChoicesWithMultipleAnswersAnswerChoices` so that the order shown on the screen is kept in the results.
-  Use `pipeInExtraMetaData` for each choice name in `MultipleTextQuestionScreen`.

Partly preparing for https://github.com/StanfordSocialNeuroscienceLab/WellPing/issues/7.