### PR TITLE
Support reusable choices array

### DIFF
--- a/config/names.json
+++ b/config/names.json
@@ -1,6 +1,0 @@
-[
-  "REDACTED:",
-  "a list",
-  "of names",
-  "here"
-]

--- a/config/survey.json
+++ b/config/survey.json
@@ -121,15 +121,7 @@
         "type": "MultipleText",
         "question": "How would you best describe your relationship to the people you had an interaction with?",
         "placeholder": "Select a category...",
-        "choices": [
-          "Friend",
-          "Co-worker",
-          "Parent",
-          "Sibling / other relative",
-          "Significant other",
-          "Stranger",
-          "Other"
-        ],
+        "choices": "RELATIONSHIPS",
         "forceChoice": true,
         "max": 3,
         "maxMinus": "SocInteraction_Names",
@@ -150,7 +142,16 @@
   },
   "extraData": {
     "reusableChoices": {
-      "NAMES": ["REDACTED:", "a list", "of names", "here"]
+      "NAMES": ["REDACTED:", "a list", "of names", "here"],
+      "RELATIONSHIPS": [
+        "Friend",
+        "Co-worker",
+        "Parent",
+        "Sibling / other relative",
+        "Significant other",
+        "Stranger",
+        "Other"
+      ]
     }
   }
 }

--- a/config/survey.json
+++ b/config/survey.json
@@ -55,21 +55,22 @@
         "question": "The current value on the slider bar is your previous response about how you currently feel. Please use the slider bar to indicate how you WOULD LIKE to feel.",
         "slider": ["extremely negative", "extremely positive"],
         "defaultValueFromQuestionId": "Feel_Current",
+        "next": "Anxiety"
+      },
+      "Anxiety": {
+        "id": "Anxiety",
+        "type": "ChoicesWithSingleAnswer",
+        "question": "Which of the following best categorizes the PRIMARY anxiety you are experiencing?",
+        "choices": "WELLBEING_CATEGORY",
+        "randomizeChoicesOrder": true,
+        "randomizeExceptForChoiceIds": ["Not experiencing stress", "Other"],
         "next": "Stressor"
       },
       "Stressor": {
         "id": "Stressor",
         "type": "ChoicesWithSingleAnswer",
         "question": "Which of the following best categorizes the PRIMARY stress you are experiencing?",
-        "choices": [
-          "Academic",
-          "Social/relationship",
-          "Mental health",
-          "Physical health",
-          "Financial",
-          "Not experiencing stress",
-          "Other"
-        ],
+        "choices": "WELLBEING_CATEGORY",
         "randomizeChoicesOrder": true,
         "randomizeExceptForChoiceIds": ["Not experiencing stress", "Other"],
         "next": "StressDurationNum"
@@ -142,6 +143,15 @@
   },
   "extraData": {
     "reusableChoices": {
+      "WELLBEING_CATEGORY": [
+        "Academic",
+        "Social/relationship",
+        "Mental health",
+        "Physical health",
+        "Financial",
+        "Not experiencing it",
+        "Other"
+      ],
       "NAMES": ["REDACTED:", "a list", "of names", "here"],
       "RELATIONSHIPS": [
         "Friend",

--- a/config/survey.json
+++ b/config/survey.json
@@ -147,5 +147,10 @@
         "next": null
       }
     }
+  },
+  "extraData": {
+    "reusableChoices": {
+      "NAMES": ["REDACTED:", "a list", "of names", "here"]
+    }
   }
 }

--- a/src/__tests__/helper.ts
+++ b/src/__tests__/helper.ts
@@ -1,11 +1,11 @@
 import * as studyFileAsyncStorage from "../helpers/asyncStorage/studyFile";
-import { StudyInfo } from "../helpers/types";
+import { StudyInfo, ExtraData } from "../helpers/types";
 import { FunctionSpyInstance } from "./jestHelper";
 
 export const simplePipeInExtraMetaData = (id: string) => id;
 
 /**
- * Notice that it is possible to `mockStudyInfo` in an outer `beforeEach`,
+ * Notice that it is possible to e.g. `mockStudyInfo` in an outer `beforeEach`,
  * and then `mockStudyInfo` again in an inner `beforeEach`.
  * The `mockStudyInfo` in the inner `beforeEach` will override the outer one.
  *
@@ -21,5 +21,15 @@ export function mockCurrentStudyInfo(
     .spyOn(studyFileAsyncStorage, "getCurrentStudyInfoAsync")
     .mockImplementation(async () => {
       return mockStudyInfo;
+    });
+}
+
+export function mockCurrentExtraData(
+  mockExtraData: ExtraData,
+): FunctionSpyInstance<typeof studyFileAsyncStorage.getCurrentExtraDataAsync> {
+  return jest
+    .spyOn(studyFileAsyncStorage, "getCurrentExtraDataAsync")
+    .mockImplementation(async () => {
+      return mockExtraData;
     });
 }

--- a/src/__tests__/helpers/schemas/Question/ChoicesQuestionSchema.test.ts
+++ b/src/__tests__/helpers/schemas/Question/ChoicesQuestionSchema.test.ts
@@ -61,7 +61,7 @@ describe("ChoicesQuestionSchema", () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
-    test("should be an array of strings", () => {
+    test("can be an array of strings", () => {
       expect(() => {
         ChoicesQuestionSchema.parse({
           ...question,
@@ -80,6 +80,29 @@ describe("ChoicesQuestionSchema", () => {
         ChoicesQuestionSchema.parse({
           ...question,
           choices: [2, 3, 5],
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test("can be a string", () => {
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: "helloworld",
+        });
+      }).not.toThrowError();
+
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: "NAMES",
+        });
+      }).not.toThrowError();
+
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: 5,
         });
       }).toThrowErrorMatchingSnapshot();
     });

--- a/src/__tests__/helpers/schemas/Question/ChoicesQuestionSchema.test.ts
+++ b/src/__tests__/helpers/schemas/Question/ChoicesQuestionSchema.test.ts
@@ -186,6 +186,18 @@ describe("ChoicesQuestionSchema", () => {
       }).not.toThrowError();
     });
 
+    test(`will not be tested if choices is string`, () => {
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: "NAMES",
+          specialCasesStartId: {
+            一尊还酹江月: "dream",
+          },
+        });
+      }).not.toThrowError();
+    });
+
     test(`can include only choices keys`, () => {
       expect(() => {
         ChoicesQuestionSchema.parse({
@@ -356,6 +368,16 @@ describe("ChoicesQuestionSchema", () => {
         ChoicesQuestionSchema.parse({
           ...question,
           randomizeExceptForChoiceIds: [],
+        });
+      }).not.toThrowError();
+    });
+
+    test(`will not be tested if choices is string`, () => {
+      expect(() => {
+        ChoicesQuestionSchema.parse({
+          ...question,
+          choices: "NAMES",
+          randomizeExceptForChoiceIds: ["花间一壶酒", "独酌无相亲"],
         });
       }).not.toThrowError();
     });

--- a/src/__tests__/helpers/schemas/Question/MultipleTextQuestionSchema.test.ts
+++ b/src/__tests__/helpers/schemas/Question/MultipleTextQuestionSchema.test.ts
@@ -339,8 +339,7 @@ describe("MultipleTextQuestionSchema", () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
-    // TODO: WILL ONLY ACCEPT URL / ARRAY IN THE FUTURE
-    test("TODO: should not be string other than `NAMES`", () => {
+    test("can be string", () => {
       expect(() => {
         MultipleTextQuestionSchema.parse({
           ...question,
@@ -353,14 +352,7 @@ describe("MultipleTextQuestionSchema", () => {
           ...question,
           choices: "helloworld",
         });
-      }).toThrowErrorMatchingSnapshot("string");
-
-      expect(() => {
-        MultipleTextQuestionSchema.parse({
-          ...question,
-          choices: "https://example.com/choices.json",
-        });
-      }).toThrowErrorMatchingSnapshot("url");
+      }).not.toThrowError();
     });
   });
 

--- a/src/__tests__/helpers/schemas/Question/__snapshots__/ChoicesQuestionSchema.test.ts.snap
+++ b/src/__tests__/helpers/schemas/Question/__snapshots__/ChoicesQuestionSchema.test.ts.snap
@@ -33,16 +33,10 @@ exports[`ChoicesQuestionSchema choices choices string cannot be empty 2`] = `
 `;
 
 exports[`ChoicesQuestionSchema choices should be an array of strings 1`] = `
-"3 validation issue(s)
+"1 validation issue(s)
 
-  Issue #0: invalid_type at choices.0
-  Expected string, received number
-
-  Issue #1: invalid_type at choices.1
-  Expected string, received number
-
-  Issue #2: invalid_type at choices.2
-  Expected string, received number
+  Issue #0: invalid_union at choices
+  Invalid input
 "
 `;
 
@@ -57,8 +51,8 @@ exports[`ChoicesQuestionSchema choices should not be empty 1`] = `
 exports[`ChoicesQuestionSchema choices should not be undefined 1`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_type at choices
-  Required
+  Issue #0: invalid_union at choices
+  Invalid input
 "
 `;
 

--- a/src/__tests__/helpers/schemas/Question/__snapshots__/ChoicesQuestionSchema.test.ts.snap
+++ b/src/__tests__/helpers/schemas/Question/__snapshots__/ChoicesQuestionSchema.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ChoicesQuestionSchema choices can be a string 1`] = `
+"1 validation issue(s)
+
+  Issue #0: invalid_union at choices
+  Invalid input
+"
+`;
+
+exports[`ChoicesQuestionSchema choices can be an array of strings 1`] = `
+"1 validation issue(s)
+
+  Issue #0: invalid_union at choices
+  Invalid input
+"
+`;
+
 exports[`ChoicesQuestionSchema choices choices should not be duplicated 1`] = `
 "1 validation issue(s)
 
@@ -29,14 +45,6 @@ exports[`ChoicesQuestionSchema choices choices string cannot be empty 2`] = `
 
   Issue #0: too_small at choices.0
   Should be at least 1 characters
-"
-`;
-
-exports[`ChoicesQuestionSchema choices should be an array of strings 1`] = `
-"1 validation issue(s)
-
-  Issue #0: invalid_union at choices
-  Invalid input
 "
 `;
 

--- a/src/__tests__/helpers/schemas/Question/__snapshots__/MultipleTextQuestionSchema.test.ts.snap
+++ b/src/__tests__/helpers/schemas/Question/__snapshots__/MultipleTextQuestionSchema.test.ts.snap
@@ -1,70 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MultipleTextQuestionSchema choices TODO: should not be string other than \`NAMES\`: string 1`] = `
-"1 validation issue(s)
-
-  Issue #0: invalid_literal_value at choices
-  Input must be \\"NAMES\\"
-"
-`;
-
-exports[`MultipleTextQuestionSchema choices TODO: should not be string other than \`NAMES\`: url 1`] = `
-"1 validation issue(s)
-
-  Issue #0: invalid_literal_value at choices
-  Input must be \\"NAMES\\"
-"
-`;
-
 exports[`MultipleTextQuestionSchema choices choices should not be duplicated 1`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_union at choices
-  Invalid input
+  Issue #0: custom_error at choices
+  There should not be duplicate elements in the choices list.
 "
 `;
 
 exports[`MultipleTextQuestionSchema choices choices should not be duplicated 2`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_union at choices
-  Invalid input
+  Issue #0: custom_error at choices
+  There should not be duplicate elements in the choices list.
 "
 `;
 
 exports[`MultipleTextQuestionSchema choices choices string cannot be empty 1`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_union at choices
-  Invalid input
+  Issue #0: too_small at choices.0
+  Should be at least 1 characters
 "
 `;
 
 exports[`MultipleTextQuestionSchema choices choices string cannot be empty 2`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_union at choices
-  Invalid input
+  Issue #0: too_small at choices.0
+  Should be at least 1 characters
 "
 `;
 
 exports[`MultipleTextQuestionSchema choices should not be anything besides array and string: number 1`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_literal_value at choices
-  Input must be \\"NAMES\\"
+  Issue #0: invalid_union at choices
+  Invalid input
 "
 `;
 
 exports[`MultipleTextQuestionSchema choices should not be anything besides array and string: object 1`] = `
-"1 validation issue(s)
-
-  Issue #0: invalid_literal_value at choices
-  Input must be \\"NAMES\\"
-"
-`;
-
-exports[`MultipleTextQuestionSchema choices should not be empty array 1`] = `
 "1 validation issue(s)
 
   Issue #0: invalid_union at choices
@@ -72,11 +48,19 @@ exports[`MultipleTextQuestionSchema choices should not be empty array 1`] = `
 "
 `;
 
+exports[`MultipleTextQuestionSchema choices should not be empty array 1`] = `
+"1 validation issue(s)
+
+  Issue #0: nonempty_array_is_empty at choices
+  List must contain at least one item
+"
+`;
+
 exports[`MultipleTextQuestionSchema choices should not be null 1`] = `
 "1 validation issue(s)
 
-  Issue #0: invalid_literal_value at choices
-  Input must be \\"NAMES\\"
+  Issue #0: invalid_union at choices
+  Invalid input
 "
 `;
 

--- a/src/__tests__/helpers/schemas/Question/__snapshots__/QuestionSchema.test.ts.snap
+++ b/src/__tests__/helpers/schemas/Question/__snapshots__/QuestionSchema.test.ts.snap
@@ -50,8 +50,8 @@ exports[`QuestionSchema mismatch type 1`] = `
   Issue #0: unrecognized_keys at 
   Unrecognized key(s) in object: 'defaultValueFromQuestionId', 'slider'
 
-  Issue #1: invalid_type at choices
-  Required
+  Issue #1: invalid_union at choices
+  Invalid input
 "
 `;
 

--- a/src/__tests__/helpers/schemas/Question/__snapshots__/QuestionsListSchema.test.ts.snap
+++ b/src/__tests__/helpers/schemas/Question/__snapshots__/QuestionsListSchema.test.ts.snap
@@ -35,8 +35,8 @@ exports[`QuestionsListSchema should not accept non-existent next: single 1`] = `
 exports[`QuestionsListSchema should show individual question error: multiple 1`] = `
 "5 validation issue(s)
 
-  Issue #0: invalid_type at choices
-  Required
+  Issue #0: invalid_union at choices
+  Invalid input
 
   Issue #1: invalid_type at slider
   Required

--- a/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
+++ b/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
@@ -24,7 +24,7 @@ import {
   Choice,
 } from "../../helpers/types";
 import ChoicesQuestionScreen from "../../questionScreens/ChoicesQuestionScreen";
-import { simplePipeInExtraMetaData } from "../helper";
+import { simplePipeInExtraMetaData, mockCurrentExtraData } from "../helper";
 
 export const getSelectionA11YLabel = (option: string) => `select ${option}`;
 export const getSelection = (
@@ -87,8 +87,9 @@ const basicTestForChoicesQuestionScreenAsync = async (
       if (question.choices === MOCK_EMOJI_CHOICES_KEY) {
         choices = MOCK_EMOJI_CHOICES_LIST;
       } else {
-        // TODO: CONSIDER THIS
-        choices = [];
+        choices = [
+          `ERROR: reusable choices with key "${question.choices}" is not found.`,
+        ];
       }
     } else {
       choices = question.choices;
@@ -120,8 +121,7 @@ const basicTestForChoicesQuestionScreenAsync = async (
 
   // Wait for the selections to be loaded.
   await waitFor(() => {
-    const newTextInput = getSelection(choices[0], getAllByA11yLabel);
-    return newTextInput;
+    return getAllByA11yLabel(/^select /).length > 0;
   });
 
   expect(mockPipeInExtraMetaData).toHaveBeenCalledTimes(choices.length); // For each choices
@@ -137,7 +137,7 @@ const basicTestForChoicesQuestionScreenAsync = async (
   );
   if (question.type !== QuestionType.YesNo) {
     if (question.randomizeChoicesOrder) {
-      expect(displayedList).not.toStrictEqual(CHOICES);
+      expect(displayedList).not.toStrictEqual(choices);
       if (question.randomizeExceptForChoiceIds) {
         // Sort the `randomizeExceptForChoiceIds` by the order of `choices`.
         const sortedRandomizeExceptForChoiceIds = [];
@@ -160,7 +160,7 @@ const basicTestForChoicesQuestionScreenAsync = async (
         }
       }
     } else {
-      expect(displayedList).toStrictEqual(CHOICES);
+      expect(displayedList).toStrictEqual(choices);
     }
   }
 
@@ -342,7 +342,98 @@ test.each(CHOICES_TEST_TABLE)(
   },
 );
 
-// TODO: TEST CHOICES STRING
+const EMOJI_CHOICES_TEST_TABLE = [
+  [true, ["😎"]],
+  [true, ["😀", "🤪"]],
+  [
+    true,
+    ["🧐", "😀"], // The order should follow `choices`, not here.
+  ],
+  [true, ["😀", "🤪", "🧐"]],
+  [true, undefined],
+  [false, undefined],
+] as [boolean, string[] | undefined][];
+test.each(EMOJI_CHOICES_TEST_TABLE)(
+  "ChoicesWithSingleAnswer question (choices string) (randomize order %p except for %p)",
+  async (randomizeChoicesOrder, randomizeExceptForChoiceIds) => {
+    mockCurrentExtraData({
+      reusableChoices: {
+        [MOCK_EMOJI_CHOICES_KEY]: MOCK_EMOJI_CHOICES_LIST,
+      },
+    });
+
+    const question = {
+      id: "AnimalTest",
+      type: QuestionType.ChoicesWithSingleAnswer,
+      question: "What emoji are you?",
+      randomizeChoicesOrder,
+      randomizeExceptForChoiceIds,
+      choices: MOCK_EMOJI_CHOICES_KEY,
+      next: null,
+    } as ChoicesWithSingleAnswerQuestion;
+
+    await basicTestForChoicesQuestionScreenAsync(question);
+  },
+);
+
+test.each(EMOJI_CHOICES_TEST_TABLE)(
+  "ChoicesWithMultipleAnswers (choices string) (randomize order %p except for %p)",
+  async (randomizeChoicesOrder, randomizeExceptForChoiceIds) => {
+    mockCurrentExtraData({
+      reusableChoices: {
+        [MOCK_EMOJI_CHOICES_KEY]: MOCK_EMOJI_CHOICES_LIST,
+      },
+    });
+
+    const question = {
+      id: "AnimalTest",
+      type: QuestionType.ChoicesWithMultipleAnswers,
+      question: "What emojis do you love?",
+      randomizeChoicesOrder,
+      randomizeExceptForChoiceIds,
+      choices: MOCK_EMOJI_CHOICES_KEY,
+      next: null,
+    } as ChoicesWithMultipleAnswersQuestion;
+
+    await basicTestForChoicesQuestionScreenAsync(question);
+  },
+);
+
+test("ChoicesWithSingleAnswer (invalid choices string)", async () => {
+  mockCurrentExtraData({
+    reusableChoices: {
+      [MOCK_EMOJI_CHOICES_KEY]: MOCK_EMOJI_CHOICES_LIST,
+    },
+  });
+
+  const question = {
+    id: "AnimalTest",
+    type: QuestionType.ChoicesWithSingleAnswer,
+    question: "Which emojis do you love?",
+    choices: "non-existent",
+    next: null,
+  } as ChoicesWithSingleAnswerQuestion;
+
+  await basicTestForChoicesQuestionScreenAsync(question);
+});
+
+test("ChoicesWithMultipleAnswers (invalid choices string)", async () => {
+  mockCurrentExtraData({
+    reusableChoices: {
+      [MOCK_EMOJI_CHOICES_KEY]: MOCK_EMOJI_CHOICES_LIST,
+    },
+  });
+
+  const question = {
+    id: "AnimalTest",
+    type: QuestionType.ChoicesWithMultipleAnswers,
+    question: "What emojis do you love?",
+    choices: "non-existent",
+    next: null,
+  } as ChoicesWithMultipleAnswersQuestion;
+
+  await basicTestForChoicesQuestionScreenAsync(question);
+});
 
 test("wrong QuestionType", async () => {
   const question = {

--- a/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
+++ b/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
@@ -21,7 +21,7 @@ import {
   YesNoQuestion,
   ChoicesWithSingleAnswerQuestion,
   ChoicesWithMultipleAnswersQuestion,
-  Choice,
+  ChoicesList,
 } from "../../helpers/types";
 import ChoicesQuestionScreen from "../../questionScreens/ChoicesQuestionScreen";
 import { simplePipeInExtraMetaData, mockCurrentExtraData } from "../helper";
@@ -79,7 +79,7 @@ const basicTestForChoicesQuestionScreenAsync = async (
     | ChoicesWithSingleAnswerQuestion
     | ChoicesWithMultipleAnswersQuestion,
 ) => {
-  let choices: Choice[];
+  let choices: ChoicesList;
   if (question.type === QuestionType.YesNo) {
     choices = ["Yes", "No"];
   } else {

--- a/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
+++ b/src/__tests__/questionScreens/ChoicesQuestionScreen.test.tsx
@@ -68,6 +68,11 @@ test.each([true, false])("YesNo question with input %p", async (inputValue) => {
   }
 });
 
+const MOCK_EMOJI_CHOICES_KEY = "emojis";
+const MOCK_EMOJI_CHOICES_LIST = ["😀", "🤪", "🧐", "😎"] as [
+  string,
+  ...string[]
+];
 const basicTestForChoicesQuestionScreenAsync = async (
   question:
     | YesNoQuestion
@@ -78,7 +83,16 @@ const basicTestForChoicesQuestionScreenAsync = async (
   if (question.type === QuestionType.YesNo) {
     choices = ["Yes", "No"];
   } else {
-    choices = question.choices;
+    if (typeof question.choices === "string") {
+      if (question.choices === MOCK_EMOJI_CHOICES_KEY) {
+        choices = MOCK_EMOJI_CHOICES_LIST;
+      } else {
+        // TODO: CONSIDER THIS
+        choices = [];
+      }
+    } else {
+      choices = question.choices;
+    }
   }
 
   // To make sure we can deterministically confirm the randomness.
@@ -102,7 +116,13 @@ const basicTestForChoicesQuestionScreenAsync = async (
       setDataValidationFunction={mockSetDataValidationFunction}
     />,
   );
-  const { findAllByA11yLabel } = renderResults;
+  const { findAllByA11yLabel, getAllByA11yLabel } = renderResults;
+
+  // Wait for the selections to be loaded.
+  await waitFor(() => {
+    const newTextInput = getSelection(choices[0], getAllByA11yLabel);
+    return newTextInput;
+  });
 
   expect(mockPipeInExtraMetaData).toHaveBeenCalledTimes(choices.length); // For each choices
 
@@ -321,6 +341,8 @@ test.each(CHOICES_TEST_TABLE)(
     );
   },
 );
+
+// TODO: TEST CHOICES STRING
 
 test("wrong QuestionType", async () => {
   const question = {

--- a/src/__tests__/questionScreens/MultipleTextQuestionScreen.test.tsx
+++ b/src/__tests__/questionScreens/MultipleTextQuestionScreen.test.tsx
@@ -367,3 +367,35 @@ test.each([
     await basicTestForQuestionAsync(question, {}, inputValues);
   },
 );
+
+// Should not have been able enter anything except "ERROR: ...".
+test.each([
+  [[]],
+  [["hello world"]],
+  [["yep", "yep", "yep"]],
+  [
+    [
+      `ERROR: reusable choices with key "invalid-reusable-choice" is not found.`,
+    ],
+  ],
+])("input `%p` with invalid string choices", async (inputValues) => {
+  mockCurrentExtraData({
+    reusableChoices: {
+      [MOCK_EMOJI_CHOICES_KEY]: MOCK_EMOJI_CHOICES_LIST,
+    },
+  });
+
+  const question = {
+    id: "WithChoicesDict",
+    type: QuestionType.MultipleText,
+    question: "A question",
+    choices: "invalid-reusable-choice",
+    forceChoice: true,
+    max: 3,
+    variableName: "TARGET_CATEGORY",
+    indexName: "INDEX",
+    next: null,
+  } as MultipleTextQuestion;
+
+  await basicTestForQuestionAsync(question, {}, inputValues);
+});

--- a/src/__tests__/questionScreens/__snapshots__/ChoicesQuestionScreen.test.tsx.snap
+++ b/src/__tests__/questionScreens/__snapshots__/ChoicesQuestionScreen.test.tsx.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ChoicesWithMultipleAnswers (choices string) (randomize order false except for undefined): displayed list 1`] = `
+Array [
+  "😀",
+  "🤪",
+  "🧐",
+  "😎",
+]
+`;
+
+exports[`ChoicesWithMultipleAnswers (choices string) (randomize order true except for ["😀", "🤪", "🧐"]): displayed list 1`] = `
+Array [
+  "😎",
+  "😀",
+  "🤪",
+  "🧐",
+]
+`;
+
+exports[`ChoicesWithMultipleAnswers (choices string) (randomize order true except for ["😀", "🤪"]): displayed list 1`] = `
+Array [
+  "😎",
+  "🧐",
+  "😀",
+  "🤪",
+]
+`;
+
+exports[`ChoicesWithMultipleAnswers (choices string) (randomize order true except for ["😎"]): displayed list 1`] = `
+Array [
+  "🤪",
+  "🧐",
+  "😀",
+  "😎",
+]
+`;
+
+exports[`ChoicesWithMultipleAnswers (choices string) (randomize order true except for ["🧐", "😀"]): displayed list 1`] = `
+Array [
+  "😎",
+  "🤪",
+  "😀",
+  "🧐",
+]
+`;
+
+exports[`ChoicesWithMultipleAnswers (choices string) (randomize order true except for undefined): displayed list 1`] = `
+Array [
+  "😎",
+  "🧐",
+  "😀",
+  "🤪",
+]
+`;
+
+exports[`ChoicesWithMultipleAnswers (invalid choices string): displayed list 1`] = `
+Array [
+  "ERROR: reusable choices with key \\"non-existent\\" is not found.",
+]
+`;
+
 exports[`ChoicesWithMultipleAnswers question with input sequence ["Coyote", "Coyote", "Wolf", "Wolf", "Coyote"] (randomize order true except for ["I don't know", "Other"]): data 1`] = `
 Array [
   Array [
@@ -312,6 +372,66 @@ Array [
   "Panda",
   "Other",
   "I don't know",
+]
+`;
+
+exports[`ChoicesWithSingleAnswer (invalid choices string): displayed list 1`] = `
+Array [
+  "ERROR: reusable choices with key \\"non-existent\\" is not found.",
+]
+`;
+
+exports[`ChoicesWithSingleAnswer question (choices string) (randomize order false except for undefined): displayed list 1`] = `
+Array [
+  "😀",
+  "🤪",
+  "🧐",
+  "😎",
+]
+`;
+
+exports[`ChoicesWithSingleAnswer question (choices string) (randomize order true except for ["😀", "🤪", "🧐"]): displayed list 1`] = `
+Array [
+  "😎",
+  "😀",
+  "🤪",
+  "🧐",
+]
+`;
+
+exports[`ChoicesWithSingleAnswer question (choices string) (randomize order true except for ["😀", "🤪"]): displayed list 1`] = `
+Array [
+  "😎",
+  "🧐",
+  "😀",
+  "🤪",
+]
+`;
+
+exports[`ChoicesWithSingleAnswer question (choices string) (randomize order true except for ["😎"]): displayed list 1`] = `
+Array [
+  "🤪",
+  "🧐",
+  "😀",
+  "😎",
+]
+`;
+
+exports[`ChoicesWithSingleAnswer question (choices string) (randomize order true except for ["🧐", "😀"]): displayed list 1`] = `
+Array [
+  "😎",
+  "🤪",
+  "😀",
+  "🧐",
+]
+`;
+
+exports[`ChoicesWithSingleAnswer question (choices string) (randomize order true except for undefined): displayed list 1`] = `
+Array [
+  "😎",
+  "🧐",
+  "😀",
+  "🤪",
 ]
 `;
 

--- a/src/__tests__/questionScreens/__snapshots__/MultipleTextQuestionScreen.test.tsx.snap
+++ b/src/__tests__/questionScreens/__snapshots__/MultipleTextQuestionScreen.test.tsx.snap
@@ -36,6 +36,19 @@ Object {
 
 exports[`input \`["I am typing 1", "I am typing 2", "I am typing 3", "I am typing 4"]\` with max 4 and forceChoice false with a choices object: text inputs length 1`] = `4`;
 
+exports[`input \`["I am typing 1", "I am typing 2", "I am typing 3", "I am typing 4"]\` with max 4 and forceChoice false with a choices string 1`] = `
+Object {
+  "value": Array [
+    "I am typing 1",
+    "I am typing 2",
+    "I am typing 3",
+    "I am typing 4",
+  ],
+}
+`;
+
+exports[`input \`["I am typing 1", "I am typing 2", "I am typing 3", "I am typing 4"]\` with max 4 and forceChoice false with a choices string: text inputs length 1`] = `4`;
+
 exports[`input \`["I am typing 1", "I am typing 2", "I am typing 3", "I am typing 4"]\` with max 4 without choices 1`] = `
 Object {
   "value": Array [
@@ -57,6 +70,14 @@ Object {
 
 exports[`input \`["I am typing 1", "I am typing 2"]\` with max 2 and forceChoice true with a choices object: text inputs length 1`] = `2`;
 
+exports[`input \`["I am typing 1", "I am typing 2"]\` with max 2 and forceChoice true with a choices string 1`] = `
+Object {
+  "value": Array [],
+}
+`;
+
+exports[`input \`["I am typing 1", "I am typing 2"]\` with max 2 and forceChoice true with a choices string: text inputs length 1`] = `2`;
+
 exports[`input \`["I am typing 1", "Sibling / other relative", "I am typing 1", "I am typing 2", "Parent"]\` with max 5 and forceChoice true with a choices object 1`] = `
 Object {
   "value": Array [
@@ -67,6 +88,17 @@ Object {
 `;
 
 exports[`input \`["I am typing 1", "Sibling / other relative", "I am typing 1", "I am typing 2", "Parent"]\` with max 5 and forceChoice true with a choices object: text inputs length 1`] = `5`;
+
+exports[`input \`["I am typing 1", "😀", "I am typing 1", "I am typing 2", "🤪"]\` with max 5 and forceChoice true with a choices string 1`] = `
+Object {
+  "value": Array [
+    "😀",
+    "🤪",
+  ],
+}
+`;
+
+exports[`input \`["I am typing 1", "😀", "I am typing 1", "I am typing 2", "🤪"]\` with max 5 and forceChoice true with a choices string: text inputs length 1`] = `5`;
 
 exports[`input \`["I am typing 1"]\` with max 3 and maxMinus "PrevQuestionId" without choices 1`] = `
 Object {
@@ -146,6 +178,43 @@ Object {
 `;
 
 exports[`input \`["Stranger", "Stranger", "Stranger", "Stranger", "RANDOM"]\` with max 5 and forceChoice false with a choices object: text inputs length 1`] = `5`;
+
+exports[`input \`["🤪", "", "🤪", ":)", "🤪"]\` with max 5 and forceChoice true with a choices string 1`] = `
+Object {
+  "value": Array [
+    "🤪",
+    "🤪",
+    "🤪",
+  ],
+}
+`;
+
+exports[`input \`["🤪", "", "🤪", ":)", "🤪"]\` with max 5 and forceChoice true with a choices string: text inputs length 1`] = `5`;
+
+exports[`input \`["🧐", "RANDOM INPUT", "😎"]\` with max 5 and forceChoice true with a choices string 1`] = `
+Object {
+  "value": Array [
+    "🧐",
+    "😎",
+  ],
+}
+`;
+
+exports[`input \`["🧐", "RANDOM INPUT", "😎"]\` with max 5 and forceChoice true with a choices string: text inputs length 1`] = `5`;
+
+exports[`input \`["🧐", "🧐", "🧐", "🧐", "RANDOM"]\` with max 5 and forceChoice false with a choices string 1`] = `
+Object {
+  "value": Array [
+    "🧐",
+    "🧐",
+    "🧐",
+    "🧐",
+    "RANDOM",
+  ],
+}
+`;
+
+exports[`input \`["🧐", "🧐", "🧐", "🧐", "RANDOM"]\` with max 5 and forceChoice false with a choices string: text inputs length 1`] = `5`;
 
 exports[`input \`[]\` with max 4 and maxMinus "PrevQuestionId" without choices 1`] = `
 Object {

--- a/src/__tests__/questionScreens/__snapshots__/MultipleTextQuestionScreen.test.tsx.snap
+++ b/src/__tests__/questionScreens/__snapshots__/MultipleTextQuestionScreen.test.tsx.snap
@@ -12,6 +12,16 @@ Object {
 
 exports[`input \`["Co-worker", "", "Co-worker", ":)", "Co-worker"]\` with max 5 and forceChoice true with a choices object: text inputs length 1`] = `5`;
 
+exports[`input \`["ERROR: reusable choices with key \\"invalid-reusable-choice\\" is not found."]\` with invalid string choices 1`] = `
+Object {
+  "value": Array [
+    "ERROR: reusable choices with key \\"invalid-reusable-choice\\" is not found.",
+  ],
+}
+`;
+
+exports[`input \`["ERROR: reusable choices with key \\"invalid-reusable-choice\\" is not found."]\` with invalid string choices: text inputs length 1`] = `3`;
+
 exports[`input \`["Friend", "RANDOM INPUT", "Other"]\` with max 5 and forceChoice true with a choices object 1`] = `
 Object {
   "value": Array [
@@ -179,6 +189,22 @@ Object {
 
 exports[`input \`["Stranger", "Stranger", "Stranger", "Stranger", "RANDOM"]\` with max 5 and forceChoice false with a choices object: text inputs length 1`] = `5`;
 
+exports[`input \`["hello world"]\` with invalid string choices 1`] = `
+Object {
+  "value": Array [],
+}
+`;
+
+exports[`input \`["hello world"]\` with invalid string choices: text inputs length 1`] = `3`;
+
+exports[`input \`["yep", "yep", "yep"]\` with invalid string choices 1`] = `
+Object {
+  "value": Array [],
+}
+`;
+
+exports[`input \`["yep", "yep", "yep"]\` with invalid string choices: text inputs length 1`] = `3`;
+
 exports[`input \`["🤪", "", "🤪", ":)", "🤪"]\` with max 5 and forceChoice true with a choices string 1`] = `
 Object {
   "value": Array [
@@ -215,6 +241,14 @@ Object {
 `;
 
 exports[`input \`["🧐", "🧐", "🧐", "🧐", "RANDOM"]\` with max 5 and forceChoice false with a choices string: text inputs length 1`] = `5`;
+
+exports[`input \`[]\` with invalid string choices 1`] = `
+Object {
+  "value": Array [],
+}
+`;
+
+exports[`input \`[]\` with invalid string choices: text inputs length 1`] = `3`;
 
 exports[`input \`[]\` with max 4 and maxMinus "PrevQuestionId" without choices 1`] = `
 Object {

--- a/src/helpers/asyncStorage/studyFile.ts
+++ b/src/helpers/asyncStorage/studyFile.ts
@@ -2,11 +2,15 @@ import { AsyncStorage } from "react-native";
 
 import { logError } from "../debug";
 import { parseJsonToStreams } from "../schemas/Stream";
-import { parseJsonToStudyInfo } from "../schemas/StudyFile";
-import { StudyFile, Streams, StudyInfo } from "../types";
+import {
+  parseJsonToStudyInfo,
+  parseJsonToExtraData,
+} from "../schemas/StudyFile";
+import { StudyFile, Streams, StudyInfo, ExtraData } from "../types";
 
 const STUDY_INFO_KEY = `currentStudyFile_StudyInfo`;
 const STREAMS_KEY = `currentStudyFile_Streams`;
+const EXTRA_DATA_KEY = `currentStudyFile_ExtraData`;
 
 export async function storeCurrentStudyFileAsync(studyFile: StudyFile) {
   try {
@@ -15,6 +19,10 @@ export async function storeCurrentStudyFileAsync(studyFile: StudyFile) {
       JSON.stringify(studyFile.studyInfo),
     );
     await AsyncStorage.setItem(STREAMS_KEY, JSON.stringify(studyFile.streams));
+    await AsyncStorage.setItem(
+      EXTRA_DATA_KEY,
+      JSON.stringify(studyFile.extraData),
+    );
   } catch (error) {
     // Error saving data
     logError(error);
@@ -25,6 +33,7 @@ export async function clearCurrentStudyFileAsync() {
   try {
     await AsyncStorage.removeItem(STUDY_INFO_KEY);
     await AsyncStorage.removeItem(STREAMS_KEY);
+    await AsyncStorage.removeItem(EXTRA_DATA_KEY);
   } catch (error) {
     // Error saving data
     logError(error);
@@ -55,6 +64,22 @@ export async function getCurrentStreamsAsync(): Promise<Streams | null> {
     }
     const streams: Streams = parseJsonToStreams(JSON.parse(value));
     return streams;
+  } catch (error) {
+    // We don't want this ill-formatted study file to be stored.
+    await clearCurrentStudyFileAsync();
+    logError(error);
+    return null;
+  }
+}
+
+export async function getCurrentExtraDataAsync(): Promise<ExtraData | null> {
+  try {
+    const value = await AsyncStorage.getItem(EXTRA_DATA_KEY);
+    if (value == null) {
+      return null;
+    }
+    const extraData: ExtraData = parseJsonToExtraData(JSON.parse(value));
+    return extraData;
   } catch (error) {
     // We don't want this ill-formatted study file to be stored.
     await clearCurrentStudyFileAsync();

--- a/src/helpers/schemas/Question.ts
+++ b/src/helpers/schemas/Question.ts
@@ -1,10 +1,10 @@
-import uniq from "lodash/uniq";
 import * as z from "zod";
 
 import {
   StreamNameSchema,
   QuestionIdSchema,
   QuestionIdSchemaNullable,
+  ChoicesListSchema,
 } from "./common";
 
 export const QuestionTypeSchema = z.enum([
@@ -31,21 +31,6 @@ export const SliderQuestionSchema = BaseQuestionSchema.extend({
   defaultValue: z.number().int().nonnegative().max(100).optional(),
   defaultValueFromQuestionId: QuestionIdSchema.optional(),
 });
-
-export const ChoiceSchema = z.string().nonempty();
-
-export const ChoicesListSchema = z
-  .array(ChoiceSchema)
-  .nonempty()
-  .refine(
-    (choices) => {
-      // Check if there is any duplicate items.
-      return choices.length === uniq(choices).length;
-    },
-    {
-      message: "There should not be duplicate elements in the choices list.",
-    },
-  );
 
 export const ChoicesQuestionSchema = BaseQuestionSchema.extend({
   type: z.union([

--- a/src/helpers/schemas/Question.ts
+++ b/src/helpers/schemas/Question.ts
@@ -143,7 +143,7 @@ export const MultipleTextQuestionSchema = BaseQuestionSchema.extend({
   indexName: z.string().nonempty(),
   variableName: z.string().nonempty(),
   placeholder: z.string().optional(),
-  choices: z.union([z.literal("NAMES"), ChoicesListSchema]).optional(),
+  choices: z.union([z.string(), ChoicesListSchema]).optional(),
   forceChoice: z.boolean().optional(),
   max: z.number().int().positive(),
   // The max number of text field will be `max` minus the number of text the

--- a/src/helpers/schemas/Question.ts
+++ b/src/helpers/schemas/Question.ts
@@ -37,7 +37,7 @@ export const ChoicesQuestionSchema = BaseQuestionSchema.extend({
     z.literal(QuestionTypeSchema.enum.ChoicesWithSingleAnswer),
     z.literal(QuestionTypeSchema.enum.ChoicesWithMultipleAnswers),
   ]),
-  choices: ChoicesListSchema,
+  choices: z.union([z.string(), ChoicesListSchema]),
   specialCasesStartId: z
     .union([
       // TODO: https://github.com/vriad/zod/issues/104
@@ -53,6 +53,10 @@ export const ChoicesQuestionSchema = BaseQuestionSchema.extend({
   .refine(
     (question) => {
       if (question.specialCasesStartId && question.choices) {
+        if (typeof question.choices === "string") {
+          // Can't check if it is using reusable choices.
+          return true;
+        }
         for (const key of Object.keys(question.specialCasesStartId)) {
           if (key !== "_pna" && !question.choices.includes(key)) {
             return false;
@@ -91,6 +95,10 @@ export const ChoicesQuestionSchema = BaseQuestionSchema.extend({
         question.randomizeExceptForChoiceIds &&
         question.randomizeChoicesOrder
       ) {
+        if (typeof question.choices === "string") {
+          // Can't check if it is using reusable choices.
+          return true;
+        }
         for (const exceptKey of question.randomizeExceptForChoiceIds) {
           if (!question.choices.includes(exceptKey)) {
             return false;

--- a/src/helpers/schemas/StudyFile.ts
+++ b/src/helpers/schemas/StudyFile.ts
@@ -1,9 +1,9 @@
 import { parseJSON } from "date-fns";
 import * as z from "zod";
 
-import { StudyFile, StudyInfo } from "../types";
+import { StudyFile, StudyInfo, ExtraData } from "../types";
 import { StreamsSchema, StreamsStartingQuestionIdsSchema } from "./Stream";
-import { StudyIdSchema, StreamNameSchema } from "./common";
+import { StudyIdSchema, StreamNameSchema, ChoicesListSchema } from "./common";
 
 export const WeekStartsOnSchema = z.union([
   z.literal(0),
@@ -218,9 +218,14 @@ export const StudyInfoSchema = z
     },
   );
 
+export const ExtraDataSchema = z.object({
+  reusableChoices: z.record(ChoicesListSchema).optional(),
+});
+
 export const StudyFileSchema = z.object({
   studyInfo: StudyInfoSchema,
   streams: StreamsSchema,
+  extraData: ExtraDataSchema,
 });
 
 // https://stackoverflow.com/a/13104500/2603230
@@ -237,6 +242,10 @@ const convertSpecialTypesInStudyInfo = (studyInfoRawJson: any) => {
 export function parseJsonToStudyInfo(rawJson: any): StudyInfo {
   convertSpecialTypesInStudyInfo(rawJson);
   return StudyInfoSchema.parse(rawJson);
+}
+
+export function parseJsonToExtraData(rawJson: any): ExtraData {
+  return ExtraDataSchema.parse(rawJson);
 }
 
 export function parseJsonToStudyFile(rawJson: any): StudyFile {

--- a/src/helpers/schemas/common.ts
+++ b/src/helpers/schemas/common.ts
@@ -2,6 +2,7 @@
  * These are common schemas that are used by other schemas.
  * It is moved here to avoid circular dependency.
  */
+import uniq from "lodash/uniq";
 import * as z from "zod";
 
 import { idRegexCheck, idRegexErrorMessage } from "./helper";
@@ -50,3 +51,18 @@ export const CustomNullable = (Schema: z.ZodType<any, any>, path: string[]) =>
 
 export const QuestionIdSchemaNullable = (path: string[]) =>
   CustomNullable(QuestionIdSchema, path);
+
+export const ChoiceSchema = z.string().nonempty();
+
+export const ChoicesListSchema = z
+  .array(ChoiceSchema)
+  .nonempty()
+  .refine(
+    (choices) => {
+      // Check if there is any duplicate items.
+      return choices.length === uniq(choices).length;
+    },
+    {
+      message: "There should not be duplicate elements in the choices list.",
+    },
+  );

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -42,6 +42,11 @@ export async function studyFileExistsAsync() {
     return false;
   }
 
+  const extraData = await getCurrentExtraDataAsync();
+  if (extraData === null) {
+    return false;
+  }
+
   return true;
 }
 

--- a/src/helpers/studyFile.ts
+++ b/src/helpers/studyFile.ts
@@ -169,6 +169,22 @@ export async function getReusableChoicesAsync(
   return null;
 }
 
+/**
+ * Returns a choices list keyed `key` in `reusableChoices` in `extraData`.
+ * If no such choices list is found, returns an array containing a single
+ * string explaining the error.
+ */
+export async function getReusableChoicesIncludeErrorAsync(
+  key: string,
+): Promise<ChoicesList> {
+  const reusableChoices = await getReusableChoicesAsync(key);
+  if (reusableChoices === null) {
+    return [`ERROR: reusable choices with key "${key}" is not found.`];
+  } else {
+    return reusableChoices;
+  }
+}
+
 export function getAllStreamNames(studyInfo: StudyInfo): StreamName[] {
   return Object.keys(studyInfo.streamsStartingQuestionIds) as StreamName[];
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -3,7 +3,6 @@ import * as z from "zod";
 import {
   QuestionSchema,
   SliderQuestionSchema,
-  ChoiceSchema,
   ChoicesQuestionSchema,
   ChoicesWithSingleAnswerQuestionSchema,
   ChoicesWithMultipleAnswersQuestionSchema,
@@ -14,14 +13,19 @@ import {
   BranchQuestionSchema,
   BranchWithRelativeComparisonQuestionSchema,
   QuestionTypeSchema,
-  ChoicesListSchema,
 } from "./schemas/Question";
 import { StreamsSchema } from "./schemas/Stream";
-import { StudyFileSchema, StudyInfoSchema } from "./schemas/StudyFile";
+import {
+  StudyFileSchema,
+  StudyInfoSchema,
+  ExtraDataSchema,
+} from "./schemas/StudyFile";
 import {
   QuestionIdSchema,
   StreamNameSchema,
   StudyIdSchema,
+  ChoiceSchema,
+  ChoicesListSchema,
 } from "./schemas/common";
 
 export type Choice = z.infer<typeof ChoiceSchema>;
@@ -67,7 +71,6 @@ export type StudyID = z.infer<typeof StudyIdSchema>;
 
 export type StudyInfo = z.infer<typeof StudyInfoSchema>;
 
-export type StudyFile = z.infer<typeof StudyFileSchema>;
+export type ExtraData = z.infer<typeof ExtraDataSchema>;
 
-// TODO: REMOVE THIS
-export type Names = string[];
+export type StudyFile = z.infer<typeof StudyFileSchema>;

--- a/src/questionScreens/ChoicesQuestionScreen.tsx
+++ b/src/questionScreens/ChoicesQuestionScreen.tsx
@@ -16,6 +16,7 @@ import {
   ChoicesWithMultipleAnswersAnswerData,
 } from "../helpers/answerTypes";
 import { QuestionType, shuffle } from "../helpers/helpers";
+import { getReusableChoicesIncludeErrorAsync } from "../helpers/studyFile";
 import { ChoicesQuestion, YesNoQuestion, Choice } from "../helpers/types";
 
 export interface ChoiceItemProps {
@@ -106,44 +107,52 @@ const ChoicesQuestionScreen: React.ElementType<ChoicesQuestionScreenProps> = ({
   React.useEffect(() => {
     // We have to use `useEffect(..., [])` here to ensure this only runs once.
     // If we don't use `useEffect`, each time the user update the state, the choices will be re-shuffled.
-    let choices: Choice[];
-    if (answerType === ChoicesAnswerType.YESNO) {
-      choices = YESNO_CHOICES;
-    } else {
-      const cQ = question as ChoicesQuestion;
-      choices = cQ.choices;
-    }
 
-    let tempFlatListData = choices.map((choice) => {
-      return {
-        id: choice,
-        title: pipeInExtraMetaData(choice),
-      };
-    });
-    if (answerType !== ChoicesAnswerType.YESNO) {
-      const cQ = question as ChoicesQuestion;
-      if (cQ.randomizeChoicesOrder) {
-        const randomizeExceptForChoiceIds =
-          cQ.randomizeExceptForChoiceIds || [];
-
-        const flatListShuffleableData = tempFlatListData.filter(
-          (value) => !randomizeExceptForChoiceIds.includes(value.id),
-        );
-        const flatListFixedDataAtLast = tempFlatListData.filter((value) =>
-          randomizeExceptForChoiceIds.includes(value.id),
-        );
-        tempFlatListData = [
-          ...shuffle(flatListShuffleableData),
-          ...flatListFixedDataAtLast,
-        ];
+    async function setupAsync() {
+      let choices: Choice[];
+      if (answerType === ChoicesAnswerType.YESNO) {
+        choices = YESNO_CHOICES;
+      } else {
+        const cQ = question as ChoicesQuestion;
+        if (typeof cQ.choices === "string") {
+          choices = await getReusableChoicesIncludeErrorAsync(cQ.choices);
+        } else {
+          choices = cQ.choices;
+        }
       }
-    }
-    setFlatListData(tempFlatListData);
 
-    // We have to specify `tempFlatListData` variable here (instead of using
-    // the `flatListData` variable) because `flatListData` might still not be
-    // updated here.
-    setSelected(initAnswerDataWithFlatListData(tempFlatListData));
+      let tempFlatListData = choices.map((choice) => {
+        return {
+          id: choice,
+          title: pipeInExtraMetaData(choice),
+        };
+      });
+      if (answerType !== ChoicesAnswerType.YESNO) {
+        const cQ = question as ChoicesQuestion;
+        if (cQ.randomizeChoicesOrder) {
+          const randomizeExceptForChoiceIds =
+            cQ.randomizeExceptForChoiceIds || [];
+
+          const flatListShuffleableData = tempFlatListData.filter(
+            (value) => !randomizeExceptForChoiceIds.includes(value.id),
+          );
+          const flatListFixedDataAtLast = tempFlatListData.filter((value) =>
+            randomizeExceptForChoiceIds.includes(value.id),
+          );
+          tempFlatListData = [
+            ...shuffle(flatListShuffleableData),
+            ...flatListFixedDataAtLast,
+          ];
+        }
+      }
+      setFlatListData(tempFlatListData);
+
+      // We have to specify `tempFlatListData` variable here (instead of using
+      // the `flatListData` variable) because `flatListData` might still not be
+      // updated here.
+      setSelected(initAnswerDataWithFlatListData(tempFlatListData));
+    }
+    setupAsync();
   }, []);
 
   return (

--- a/src/questionScreens/ChoicesQuestionScreen.tsx
+++ b/src/questionScreens/ChoicesQuestionScreen.tsx
@@ -79,14 +79,6 @@ const ChoicesQuestionScreen: React.ElementType<ChoicesQuestionScreenProps> = ({
       throw new Error("Wrong QuestionType in ChoicesQuestionScreen");
   }
 
-  let choices: Choice[];
-  if (answerType === ChoicesAnswerType.YESNO) {
-    choices = YESNO_CHOICES;
-  } else {
-    const cQ = question as ChoicesQuestion;
-    choices = cQ.choices;
-  }
-
   const listRef = React.useRef<FlatList<{ id: string; title: string }>>(null);
 
   const [selected, setSelected] = React.useState<
@@ -114,6 +106,14 @@ const ChoicesQuestionScreen: React.ElementType<ChoicesQuestionScreenProps> = ({
   React.useEffect(() => {
     // We have to use `useEffect(..., [])` here to ensure this only runs once.
     // If we don't use `useEffect`, each time the user update the state, the choices will be re-shuffled.
+    let choices: Choice[];
+    if (answerType === ChoicesAnswerType.YESNO) {
+      choices = YESNO_CHOICES;
+    } else {
+      const cQ = question as ChoicesQuestion;
+      choices = cQ.choices;
+    }
+
     let tempFlatListData = choices.map((choice) => {
       return {
         id: choice,

--- a/src/questionScreens/MultipleTextQuestionScreen.tsx
+++ b/src/questionScreens/MultipleTextQuestionScreen.tsx
@@ -7,7 +7,7 @@ import {
   QuestionScreenProps,
   MultipleTextAnswerData,
 } from "../helpers/answerTypes";
-import { getReusableChoicesAsync } from "../helpers/studyFile";
+import { getReusableChoicesIncludeErrorAsync } from "../helpers/studyFile";
 import { MultipleTextQuestion, ChoicesList } from "../helpers/types";
 // @ts-ignore
 import SearchableDropdown from "../inc/react-native-searchable-dropdown";
@@ -61,14 +61,9 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
     async function setupTextFieldsDropdownItemsAsync() {
       let tempChoices!: ChoicesList;
       if (typeof question.choices === "string") {
-        const reusableChoices = await getReusableChoicesAsync(question.choices);
-        if (reusableChoices === null) {
-          tempChoices = [
-            `ERROR: getReusableChoices("${question.choices}") = null`,
-          ];
-        } else {
-          tempChoices = reusableChoices;
-        }
+        tempChoices = await getReusableChoicesIncludeErrorAsync(
+          question.choices,
+        );
       } else if (question.choices) {
         tempChoices = question.choices;
       }

--- a/src/questionScreens/MultipleTextQuestionScreen.tsx
+++ b/src/questionScreens/MultipleTextQuestionScreen.tsx
@@ -7,8 +7,8 @@ import {
   QuestionScreenProps,
   MultipleTextAnswerData,
 } from "../helpers/answerTypes";
-import { getNamesFileAsync } from "../helpers/studyFile";
-import { MultipleTextQuestion, Names } from "../helpers/types";
+import { getReusableChoicesAsync } from "../helpers/studyFile";
+import { MultipleTextQuestion, ChoicesList } from "../helpers/types";
 // @ts-ignore
 import SearchableDropdown from "../inc/react-native-searchable-dropdown";
 
@@ -23,6 +23,11 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
   pipeInExtraMetaData,
   setDataValidationFunction,
 }) => {
+  type DropdownItem = {
+    id: string;
+    name: string;
+  };
+
   let numberOfTextFields = question.max;
   if (question.maxMinus) {
     const prevQuestionAnswer = allAnswers[
@@ -40,14 +45,42 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
 
   const [textValues, setTextValues] = React.useState<string[]>(initTextValues);
 
+  const [textFieldsDropdownItems, setTextFieldsDropdownItems] = React.useState<
+    DropdownItem[]
+  >([]);
+  const textFieldsDropdownNames = textFieldsDropdownItems.map(
+    (item) => item.name,
+  );
+
   React.useEffect(() => {
-    // Re-fetch stored choices list (once) if necessary
-    // TODO: ALLOW TO FIND LIST FROM DIFF. SOURCE STORED
-    if (typeof question.choices == "string") {
-      getNamesFileAsync().then((list) => {
-        setPrestoredChoicesList(list);
-      });
+    // Should only be called once.
+    setDataValidationFunction(() => {
+      return dataValidationFunction(true);
+    });
+
+    async function setupTextFieldsDropdownItemsAsync() {
+      let tempChoices!: ChoicesList;
+      if (typeof question.choices === "string") {
+        const reusableChoices = await getReusableChoicesAsync(question.choices);
+        if (reusableChoices === null) {
+          tempChoices = [
+            `ERROR: getReusableChoices("${question.choices}") = null`,
+          ];
+        } else {
+          tempChoices = reusableChoices;
+        }
+      } else if (question.choices) {
+        tempChoices = question.choices;
+      }
+      setTextFieldsDropdownItems(
+        tempChoices.map((choice) => ({
+          id: choice,
+          name: pipeInExtraMetaData(choice),
+        })),
+      );
     }
+    // So that async can be used in `setupTextFieldsDropdownItemsAsync`.
+    setupTextFieldsDropdownItemsAsync();
   }, []);
 
   const updateTextValue = (text: string, index: number) => {
@@ -59,31 +92,6 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
     const data: MultipleTextAnswerData = { value: nonEmptyFields };
     onDataChange(data);
   };
-
-  const [prestoredChoicesList, setPrestoredChoicesList] = React.useState<
-    string[]
-  >([]);
-  const prestoredChoicesListItems = prestoredChoicesList.map((name, index) => ({
-    id: `${index}`,
-    name,
-  }));
-
-  type DropdownItem = {
-    id: string;
-    name: string;
-  };
-  let textFieldsDropdownItems: DropdownItem[] = [];
-  if (question.choices === "NAMES") {
-    textFieldsDropdownItems = prestoredChoicesListItems;
-  } else if (question.choices) {
-    textFieldsDropdownItems = question.choices.map((choice) => ({
-      id: choice,
-      name: pipeInExtraMetaData(choice),
-    }));
-  }
-  const textFieldsDropdownNames = textFieldsDropdownItems.map(
-    (item) => item.name,
-  );
 
   const textFields: SearchableDropdown[] = [];
   const textFieldsRef: React.RefObject<TextInput>[] = [];
@@ -204,9 +212,6 @@ const MultipleTextQuestionScreen: React.ElementType<MultipleTextQuestionScreenPr
     }
     return false;
   };
-  setDataValidationFunction(() => {
-    return dataValidationFunction(true);
-  });
 
   return <View style={{ paddingTop: 10 }}>{textFields}</View>;
 };


### PR DESCRIPTION
- Support using `extraData.reusableChoices` in the study file to store reusable choices.
- Support reusable choices in `ChoicesQuestionScreen`.
- Add test for using reusable choices in `ChoicesQuestionScreen` and `MultipleTextQuestionScreen`.

Resolves https://github.com/StanfordSocialNeuroscienceLab/WellPing/issues/7. Part of https://github.com/StanfordSocialNeuroscienceLab/WellPing/issues/11.