### PR TITLE
Cleanup `AnswerEntity`

### DIFF
--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -423,7 +423,7 @@ export default class HomeScreen extends React.Component<
               answer.ping = ping;
               answer.questionId = "qu";
               answer.questionType = QuestionType.YesNo;
-              answer.preferNotToAnswer = false;
+              answer.preferNotToAnswer = null;
               answer.data = {
                 value: "haha",
               };

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -424,7 +424,6 @@ export default class HomeScreen extends React.Component<
               answer.questionId = "qu";
               answer.questionType = QuestionType.YesNo;
               answer.preferNotToAnswer = false;
-              answer.nextWithoutOption = false;
               answer.data = {
                 value: "haha",
               };

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -427,7 +427,7 @@ export default class HomeScreen extends React.Component<
               answer.data = {
                 value: "haha",
               };
-              answer.lastUpdateDate = new Date();
+              answer.date = new Date();
               await answer.save();*/
 
               await shareDatabaseFileAsync(studyInfo.id);

--- a/src/SurveyScreen.tsx
+++ b/src/SurveyScreen.tsx
@@ -672,11 +672,11 @@ export default class SurveyScreen extends React.Component<
   async addAnswerToAnswersListAsync(
     question: Question,
     {
-      preferNotToAnswer = false,
+      preferNotToAnswer = null,
       data = null,
       lastUpdateDate = new Date(),
     }: {
-      preferNotToAnswer?: boolean;
+      preferNotToAnswer?: true | null; // See `MARK: WHY_PNA_TRUE_OR_NULL`.
       data?: AnswerData | null;
       lastUpdateDate?: Date;
     },

--- a/src/SurveyScreen.tsx
+++ b/src/SurveyScreen.tsx
@@ -674,11 +674,11 @@ export default class SurveyScreen extends React.Component<
     {
       preferNotToAnswer = null,
       data = null,
-      lastUpdateDate = new Date(),
+      date = new Date(),
     }: {
       preferNotToAnswer?: true | null; // See `MARK: WHY_PNA_TRUE_OR_NULL`.
       data?: AnswerData | null;
-      lastUpdateDate?: Date;
+      date?: Date;
     },
   ): Promise<void> {
     const realQuestionId = this.getRealQuestionId(question.id);
@@ -689,7 +689,7 @@ export default class SurveyScreen extends React.Component<
       realQuestionId,
       preferNotToAnswer,
       data,
-      lastUpdateDate,
+      date,
     });
 
     await new Promise((resolve, reject) => {

--- a/src/SurveyScreen.tsx
+++ b/src/SurveyScreen.tsx
@@ -490,21 +490,21 @@ export default class SurveyScreen extends React.Component<
         throw new Error("prevAnswer !== undefined but it is a user question!");
       }
 
-      if (
-        prevAnswer.preferNotToAnswer &&
-        prevQuestion.fallbackNext?.preferNotToAnswer !== undefined
-      ) {
-        nextQuestionData.questionId =
-          prevQuestion.fallbackNext.preferNotToAnswer;
-      } else if (
-        prevAnswer.nextWithoutOption &&
-        prevQuestion.fallbackNext?.nextWithoutAnswering !== undefined
-      ) {
-        nextQuestionData.questionId =
-          prevQuestion.fallbackNext.nextWithoutAnswering;
-      }
-
-      if (prevAnswer.data !== null) {
+      if (prevAnswer.preferNotToAnswer) {
+        if (prevQuestion.fallbackNext?.preferNotToAnswer !== undefined) {
+          nextQuestionData.questionId =
+            prevQuestion.fallbackNext.preferNotToAnswer;
+        }
+      } else if (prevAnswer.data === null) {
+        // If `prevAnswer.preferNotToAnswer` is not true and `prevAnswer.data
+        // === null`, it means that the user clicked "Next" without answering.
+        if (prevQuestion.fallbackNext?.nextWithoutAnswering !== undefined) {
+          nextQuestionData.questionId =
+            prevQuestion.fallbackNext.nextWithoutAnswering;
+        }
+      } else {
+        // If `prevAnswer.data !== null` and `prevAnswer.preferNotToAnswer` is
+        // not true. It means that the user answered the question normally.
         switch (prevQuestion.type) {
           case QuestionType.YesNo:
             handleYesNoQuestion(
@@ -673,12 +673,10 @@ export default class SurveyScreen extends React.Component<
     question: Question,
     {
       preferNotToAnswer = false,
-      nextWithoutOption = false,
       data = null,
       lastUpdateDate = new Date(),
     }: {
       preferNotToAnswer?: boolean;
-      nextWithoutOption?: boolean;
       data?: AnswerData | null;
       lastUpdateDate?: Date;
     },
@@ -690,7 +688,6 @@ export default class SurveyScreen extends React.Component<
       question,
       realQuestionId,
       preferNotToAnswer,
-      nextWithoutOption,
       data,
       lastUpdateDate,
     });
@@ -837,8 +834,9 @@ export default class SurveyScreen extends React.Component<
               }
 
               if (answers[realQuestionId] == null) {
+                // The user clicks "Next" without answering.
                 await this.addAnswerToAnswersListAsync(question, {
-                  nextWithoutOption: true,
+                  data: null,
                 });
               }
               this.onNextSelect();

--- a/src/entities/AnswerEntity.ts
+++ b/src/entities/AnswerEntity.ts
@@ -37,8 +37,14 @@ export abstract class AnswerEntity extends BaseEntity {
   @Column({ type: "varchar", primary: true })
   questionId: QuestionId;
 
-  @Column()
-  preferNotToAnswer: boolean;
+  @Column({ nullable: true })
+  /**
+   * MARK: WHY_PNA_TRUE_OR_NULL
+   * It should not be set to `false`. Instead, it should be either `null` or
+   * `false`. This is because using `null` means this key will not be stored in
+   * Firebase and hence saving the storage needed for each question.
+   */
+  preferNotToAnswer: true | null;
 
   @Column({ type: "simple-json", nullable: true })
   data: AnswerData | null;

--- a/src/entities/AnswerEntity.ts
+++ b/src/entities/AnswerEntity.ts
@@ -49,8 +49,12 @@ export abstract class AnswerEntity extends BaseEntity {
   @Column({ type: "simple-json", nullable: true })
   data: AnswerData | null;
 
+  /**
+   * The last update date for the answer (i.e., the last time the user interact
+   * with this question - usually when the user clicks "Next").
+   */
   @Column()
-  lastUpdateDate: Date;
+  date: Date;
 
   // https://github.com/microsoft/TypeScript/issues/5863#issuecomment-169173943
   static async findAnswerInPingAsync<T extends AnswerEntity>(

--- a/src/entities/AnswerEntity.ts
+++ b/src/entities/AnswerEntity.ts
@@ -40,9 +40,6 @@ export abstract class AnswerEntity extends BaseEntity {
   @Column()
   preferNotToAnswer: boolean;
 
-  @Column()
-  nextWithoutOption: boolean;
-
   @Column({ type: "simple-json", nullable: true })
   data: AnswerData | null;
 

--- a/src/entities/AnswerEntity.ts
+++ b/src/entities/AnswerEntity.ts
@@ -37,15 +37,19 @@ export abstract class AnswerEntity extends BaseEntity {
   @Column({ type: "varchar", primary: true })
   questionId: QuestionId;
 
-  @Column({ nullable: true })
   /**
    * MARK: WHY_PNA_TRUE_OR_NULL
    * It should not be set to `false`. Instead, it should be either `null` or
    * `false`. This is because using `null` means this key will not be stored in
    * Firebase and hence saving the storage needed for each question.
    */
+  @Column({ nullable: true })
   preferNotToAnswer: true | null;
 
+  /**
+   * If `null` (and `preferNotToAnswer` is not true), it means that the user
+   * clicks "Next" without answering.
+   */
   @Column({ type: "simple-json", nullable: true })
   data: AnswerData | null;
 

--- a/src/entities/AnswerEntity.ts
+++ b/src/entities/AnswerEntity.ts
@@ -39,6 +39,7 @@ export abstract class AnswerEntity extends BaseEntity {
 
   /**
    * MARK: WHY_PNA_TRUE_OR_NULL
+   *
    * It should not be set to `false`. Instead, it should be either `null` or
    * `false`. This is because using `null` means this key will not be stored in
    * Firebase and hence saving the storage needed for each question.

--- a/src/helpers/answers.ts
+++ b/src/helpers/answers.ts
@@ -15,7 +15,6 @@ export async function insertAnswerAsync({
   question,
   realQuestionId,
   preferNotToAnswer,
-  nextWithoutOption,
   data,
   lastUpdateDate,
 }: {
@@ -23,7 +22,6 @@ export async function insertAnswerAsync({
   question: Question;
   realQuestionId: string;
   preferNotToAnswer: boolean;
-  nextWithoutOption: boolean;
   data: AnswerData | null;
   lastUpdateDate: Date;
 }): Promise<AnswerEntity> {
@@ -31,7 +29,6 @@ export async function insertAnswerAsync({
   answer.ping = ping;
   answer.questionId = realQuestionId;
   answer.preferNotToAnswer = preferNotToAnswer;
-  answer.nextWithoutOption = nextWithoutOption;
   answer.data = data;
   answer.lastUpdateDate = lastUpdateDate;
   await answer.save();

--- a/src/helpers/answers.ts
+++ b/src/helpers/answers.ts
@@ -21,7 +21,7 @@ export async function insertAnswerAsync({
   ping: PingEntity;
   question: Question;
   realQuestionId: string;
-  preferNotToAnswer: boolean;
+  preferNotToAnswer: true | null; // See `MARK: WHY_PNA_TRUE_OR_NULL`.
   data: AnswerData | null;
   lastUpdateDate: Date;
 }): Promise<AnswerEntity> {

--- a/src/helpers/answers.ts
+++ b/src/helpers/answers.ts
@@ -5,7 +5,7 @@ import { Question } from "./types";
 
 export async function getAnswersAsync(): Promise<AnswerEntity[]> {
   const answers = await AnswerEntity.createQueryBuilder()
-    .orderBy("lastUpdateDate", "ASC")
+    .orderBy("date", "ASC")
     .getMany();
   return answers;
 }
@@ -16,21 +16,21 @@ export async function insertAnswerAsync({
   realQuestionId,
   preferNotToAnswer,
   data,
-  lastUpdateDate,
+  date,
 }: {
   ping: PingEntity;
   question: Question;
   realQuestionId: string;
   preferNotToAnswer: true | null; // See `MARK: WHY_PNA_TRUE_OR_NULL`.
   data: AnswerData | null;
-  lastUpdateDate: Date;
+  date: Date;
 }): Promise<AnswerEntity> {
   const answer = getAnswerEntity(question.type);
   answer.ping = ping;
   answer.questionId = realQuestionId;
   answer.preferNotToAnswer = preferNotToAnswer;
   answer.data = data;
-  answer.lastUpdateDate = lastUpdateDate;
+  answer.date = date;
   await answer.save();
 
   // Make sure state and database are consistent.


### PR DESCRIPTION
- Remove `nextWithoutOption` key in `AnswerEntity` as `data` being `null` and `preferNotToAnswer` not being `true` already show that the user clicked "Next" without answering.
- Change `preferNotToAnswer`'s type from `boolean` to `true | null`. This is because using `null` means that this key will not be stored in Firebase and hence saving the storage needed for each question (as there doesn't need to be a `preferNotToAnswer` key for each question).
- Rename `lastUpdateDate` to `date`.