### PR TITLE
Use expo-secure-store to store username and password

### DIFF
--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -34,7 +34,6 @@ import {
   clearPingStateAsync,
 } from "./helpers/asyncStorage/pingState";
 import { getPingsListAsync } from "./helpers/asyncStorage/pingsList";
-import { getUserAsync } from "./helpers/asyncStorage/user";
 import { clearAllPingsAndAnswersAsync } from "./helpers/cleanup";
 import { uploadDataAsync, getAllDataAsync } from "./helpers/dataUpload";
 import {
@@ -58,6 +57,7 @@ import {
   insertPingAsync,
   getNumbersOfPingsForAllStreamNamesAsync,
 } from "./helpers/pings";
+import { secureGetUserAsync } from "./helpers/secureStore/user";
 import { getSymbolsForServerTypeUsed, useFirebase } from "./helpers/server";
 import { getAllStreamNames, getStudyInfoAsync } from "./helpers/studyFile";
 import { styles } from "./helpers/styles";
@@ -207,7 +207,7 @@ export default class HomeScreen extends React.Component<
             // The user is not signed in to Firebase.
 
             // We will try to log in the user again first.
-            const localStoredUser = await getUserAsync();
+            const localStoredUser = await secureGetUserAsync();
             if (localStoredUser === null) {
               alertWithShareButtonContainingDebugInfo(
                 "Not logged in locally!",
@@ -366,7 +366,7 @@ export default class HomeScreen extends React.Component<
               {studyInfo.contactEmail && (
                 <TouchableWithoutFeedback
                   onPress={async () => {
-                    const user = await getUserAsync();
+                    const user = await secureGetUserAsync();
 
                     const emailSubject = encodeURIComponent(
                       `Questions about Well Ping study ${studyInfo.id}`,
@@ -516,9 +516,9 @@ export default class HomeScreen extends React.Component<
           />
           <Button
             color="orange"
-            title="getUserAsync()"
+            title="secureGetUserAsync()"
             onPress={async () => {
-              const user = await getUserAsync();
+              const user = await secureGetUserAsync();
               alertWithShareButtonContainingDebugInfo(JSON.stringify(user));
             }}
           />

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -9,16 +9,12 @@ import {
   clearTempStudyFileAsync,
 } from "./helpers/asyncStorage/tempStudyFile";
 import {
-  getUserAsync,
-  User,
-  clearUserAsync,
-} from "./helpers/asyncStorage/user";
-import {
   getCriticalProblemTextForUser,
   alertWithShareButtonContainingDebugInfo,
   getNonCriticalProblemTextForUser,
 } from "./helpers/debug";
 import { validateAndInitializeFirebaseWithConfig } from "./helpers/firebase";
+import { secureGetUserAsync, User } from "./helpers/secureStore/user";
 import { useFirebase } from "./helpers/server";
 import {
   getStudyFileAsync,
@@ -158,7 +154,7 @@ export default class RootScreen extends React.Component<
         }
       }
 
-      const user = await getUserAsync();
+      const user = await secureGetUserAsync();
       if (user === null) {
         // This should never happen. But just in case.
         // Notice that we have to do this before `downloadAndParseStudyFileAsync`

--- a/src/components/DashboardComponent.tsx
+++ b/src/components/DashboardComponent.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import { Text, View } from "react-native";
 import { WebView } from "react-native-webview";
 
-import { getUserAsync } from "../helpers/asyncStorage/user";
 import {
   getPingsAsync,
   getThisWeekPingsAsync,
   getTodayPingsAsync,
 } from "../helpers/pings";
+import { secureGetUserAsync } from "../helpers/secureStore/user";
 import { StudyInfo } from "../helpers/types";
 
 const USERNAME_PLACEHOLDER = "__USERNAME__";
@@ -24,7 +24,7 @@ export async function getDashboardUrlAsync(
 
   if (dashboardUrl.includes(USERNAME_PLACEHOLDER)) {
     let username = "N/A";
-    const user = await getUserAsync();
+    const user = await secureGetUserAsync();
     if (user) {
       username = user.username;
     }

--- a/src/helpers/beiwe.ts
+++ b/src/helpers/beiwe.ts
@@ -8,9 +8,9 @@ import * as Crypto from "expo-crypto";
 import * as Device from "expo-device";
 import { Platform } from "react-native";
 
-import { User, getUserAsync } from "./asyncStorage/user";
 import { UploadData } from "./dataUpload";
 import { JS_VERSION_NUMBER } from "./debug";
+import { User, secureGetUserAsync } from "./secureStore/user";
 import { getBeiweServerConfig } from "./server";
 import { getStudyInfoAsync } from "./studyFile";
 
@@ -54,10 +54,12 @@ export async function beiweUploadDataForUserAsync(
 ): Promise<Error | null> {
   startUploading();
 
-  const user = await getUserAsync();
+  const user = await secureGetUserAsync();
   if (user === null) {
     endUploading("BW: U=N");
-    return new Error("getUserAsync() === null in beiweUploadDataForUserAsync");
+    return new Error(
+      "secureGetUserAsync() === null in beiweUploadDataForUserAsync",
+    );
   }
 
   try {
@@ -92,7 +94,7 @@ async function getRequestURLAsync(
 ): Promise<string> {
   let user: User | null = forUser || null;
   if (!user) {
-    user = await getUserAsync();
+    user = await secureGetUserAsync();
 
     if (user == null) {
       throw new Error("user == null in getRequestURLAsync");

--- a/src/helpers/dataUpload.ts
+++ b/src/helpers/dataUpload.ts
@@ -1,6 +1,5 @@
 import { Answer } from "./answerTypes";
 import { getAnswersAsync } from "./answers";
-import { getUserAsync } from "./asyncStorage/user";
 import { beiweUploadDataForUserAsync } from "./beiwe";
 import {
   UserInstallationInfo,
@@ -9,6 +8,7 @@ import {
 } from "./debug";
 import { firebaseUploadDataForUserAsync } from "./firebase";
 import { getPingsAsync } from "./pings";
+import { secureGetUserAsync } from "./secureStore/user";
 import { useFirebase, useServer, useBeiwe } from "./server";
 import { StudyInfo, Ping } from "./types";
 
@@ -22,7 +22,7 @@ export type UploadData = {
 };
 
 export async function getAllDataAsync(): Promise<UploadData> {
-  const user = await getUserAsync();
+  const user = await secureGetUserAsync();
   const pings = await getPingsAsync();
   const answers = await getAnswersAsync();
 

--- a/src/helpers/firebase.ts
+++ b/src/helpers/firebase.ts
@@ -5,9 +5,9 @@
 
 import * as firebase from "firebase/app";
 
-import { User } from "./asyncStorage/user";
 import { UploadData } from "./dataUpload";
 import { INSTALLATION_ID } from "./debug";
+import { User } from "./secureStore/user";
 import { getFirebaseServerConfig } from "./server";
 import { StudyInfo } from "./types";
 

--- a/src/helpers/secureStore/user.ts
+++ b/src/helpers/secureStore/user.ts
@@ -1,8 +1,8 @@
-import AsyncStorage from "@react-native-community/async-storage";
+import * as SecureStore from "expo-secure-store";
 
 import { _DEBUG_CONFIGS } from "../../../config/debug";
 import { logAndThrowError } from "../debug";
-import { getASKeyAsync } from "./asyncStorage";
+import { getSSKeyAsync } from "./secureStore";
 
 export type User = {
   username: string;
@@ -11,10 +11,10 @@ export type User = {
 
 const USER_KEY = `user`;
 
-export async function storeUserAsync(user: User) {
+export async function secureStoreUserAsync(user: User) {
   try {
-    await AsyncStorage.setItem(
-      await getASKeyAsync(USER_KEY),
+    await SecureStore.setItemAsync(
+      await getSSKeyAsync(USER_KEY),
       JSON.stringify(user),
     );
   } catch (error) {
@@ -22,17 +22,17 @@ export async function storeUserAsync(user: User) {
   }
 }
 
-export async function clearUserAsync() {
+export async function secureClearUserAsync() {
   try {
-    await AsyncStorage.removeItem(await getASKeyAsync(USER_KEY));
+    await SecureStore.deleteItemAsync(await getSSKeyAsync(USER_KEY));
   } catch (error) {
     logAndThrowError(error);
   }
 }
 
-export async function getUserAsync(): Promise<User | null> {
+export async function secureGetUserAsync(): Promise<User | null> {
   try {
-    const value = await AsyncStorage.getItem(await getASKeyAsync(USER_KEY));
+    const value = await SecureStore.getItemAsync(await getSSKeyAsync(USER_KEY));
     if (value == null) {
       return null;
     }

--- a/src/helpers/users.ts
+++ b/src/helpers/users.ts
@@ -1,5 +1,4 @@
 import { clearCurrentStudyFileAsync } from "./asyncStorage/studyFile";
-import { storeUserAsync, User, clearUserAsync } from "./asyncStorage/user";
 import { beiweLoginAsync } from "./beiwe";
 import { clearAllPingsAndAnswersAsync } from "./cleanup";
 import {
@@ -7,6 +6,11 @@ import {
   firebaseLogoutAndDeleteAppAsync,
   firebaseInitialized,
 } from "./firebase";
+import {
+  secureStoreUserAsync,
+  secureClearUserAsync,
+  User,
+} from "./secureStore/user";
 import { useFirebase, useBeiwe, useServer } from "./server";
 import { getStudyInfoAsync, studyFileExistsAsync } from "./studyFile";
 import { StudyInfo } from "./types";
@@ -26,7 +30,7 @@ export async function loginAsync(user: User, studyInfo: StudyInfo) {
     await new Promise((r) => setTimeout(r, 3000)); // Simulate loading.
   }
 
-  await storeUserAsync(user);
+  await secureStoreUserAsync(user);
 }
 
 export async function logoutAsync() {
@@ -38,6 +42,6 @@ export async function logoutAsync() {
     await clearAllPingsAndAnswersAsync();
   }
 
-  await clearUserAsync();
+  await secureClearUserAsync();
   await clearCurrentStudyFileAsync();
 }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -12,7 +12,6 @@ import {
   TouchableWithoutFeedback,
 } from "react-native";
 
-import { User } from "../helpers/asyncStorage/user";
 import {
   JS_VERSION_NUMBER,
   alertWithShareButtonContainingDebugInfo,
@@ -20,6 +19,7 @@ import {
   shareDebugText,
 } from "../helpers/debug";
 import { LoginSchema } from "../helpers/schemas/Login";
+import { User } from "../helpers/secureStore/user";
 import { getStudyFileAsync } from "../helpers/studyFile";
 import { loginAsync, logoutAsync } from "../helpers/users";
 


### PR DESCRIPTION
Resolves #40.

Notice: "data persist across installation on iOS" problem mentioned in #40 has already been addressed by adding the installation ID to the key of an item in `getSSKeyAsync` function:
https://github.com/StanfordSocialNeuroscienceLab/WellPing/blob/7bd0da616b8261db2fe0e10010331030a12ec4fe/src/helpers/secureStore/secureStore.ts#L4-L12